### PR TITLE
Clean up logging

### DIFF
--- a/app/__init__.py
+++ b/app/__init__.py
@@ -6,16 +6,13 @@ import sys
 # Add the app directory to Python path
 sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 try:
-    # Import transit providers first - this will trigger automatic discovery
-    import transit_providers
-    try:
-        from . import transit_providers  # noqa
-    except ImportError:
-        pass
+    # Import transit providers - this will trigger automatic discovery
+    from . import transit_providers  # noqa
 
-    __all__ = ['transit_providers']
+    __all__ = ["transit_providers"]
     # Export the Flask app instance
     from . import main
+
     app = main.app
 
 except:

--- a/app/config/__init__.py
+++ b/app/config/__init__.py
@@ -6,19 +6,19 @@ with fallback to default.py.
 
 import importlib.util
 import logging
+from logging.config import dictConfig
 from pathlib import Path
 from typing import Any, Optional
 
-# Initialize logger
-logger = logging.getLogger(__name__)
 
+# Import configuration modules first
 def _import_config(module_name: str) -> Optional[Any]:
     """
     Dynamically import a configuration module.
-    
+
     Args:
         module_name: Name of the module to import (e.g., 'local' or 'default')
-        
+
     Returns:
         Module object if successful, None otherwise
     """
@@ -30,24 +30,41 @@ def _import_config(module_name: str) -> Optional[Any]:
         spec.loader.exec_module(module)  # type: ignore
         return module
     except Exception as e:
-        logger.warning(f"Could not import config.{module_name}: {str(e)}")
+        print(
+            f"Could not import config.{module_name}: {str(e)}"
+        )  # Use print since logging is not set up yet
         return None
 
+
 # Import configuration modules
-local_config = _import_config('local')
-default_config = _import_config('default')
+local_config = _import_config("local")
+default_config = _import_config("default")
+
+# Initialize logging configuration once
+logging_config = None
+if hasattr(local_config, "LOGGING_CONFIG"):
+    logging_config = getattr(local_config, "LOGGING_CONFIG")
+elif hasattr(default_config, "LOGGING_CONFIG"):
+    logging_config = getattr(default_config, "LOGGING_CONFIG")
+
+if logging_config:
+    dictConfig(logging_config)
+
+# Initialize logger after logging is configured
+logger = logging.getLogger(__name__)
+
 
 def get_config(key: str, default_value: Any = None) -> Any:
     """
     Get a configuration value, checking local.py first, then default.py.
-    
+
     Args:
         key: The configuration key to look up
         default_value: Value to return if key is not found in either config
-        
+
     Returns:
         The configuration value, or default_value if not found
-        
+
     Example:
         >>> map_config = get_config('MAP_CONFIG')
         >>> stib_stops = get_config('STIB_STOPS', [])
@@ -55,57 +72,62 @@ def get_config(key: str, default_value: Any = None) -> Any:
     # Try local config first
     if local_config and hasattr(local_config, key):
         return getattr(local_config, key)
-    
+
     # Fall back to default config
     if default_config and hasattr(default_config, key):
         return getattr(default_config, key)
-    
+
     # Return default value if key not found
     return default_value
+
 
 def get_required_config(key: str) -> Any:
     """
     Get a required configuration value. Raises an error if not found.
-    
+
     Args:
         key: The configuration key to look up
-        
+
     Returns:
         The configuration value
-        
+
     Raises:
         ValueError: If the configuration key is not found
-        
+
     Example:
         >>> api_key = get_required_config('API_KEY')
     """
     value = get_config(key)
     if value is None:
-        raise ValueError(f"Required configuration key '{key}' not found in either local.py or default.py")
+        raise ValueError(
+            f"Required configuration key '{key}' not found in either local.py or default.py"
+        )
     return value
+
 
 def list_config_keys() -> set:
     """
     Get a set of all available configuration keys.
-    
+
     Returns:
         Set of configuration key names
-        
+
     Example:
         >>> keys = list_config_keys()
         >>> print("Available config keys:", keys)
     """
     keys = set()
-    
+
     # Add keys from default config
     if default_config:
-        keys.update(k for k in dir(default_config) if not k.startswith('_'))
-    
+        keys.update(k for k in dir(default_config) if not k.startswith("_"))
+
     # Add keys from local config
     if local_config:
-        keys.update(k for k in dir(local_config) if not k.startswith('_'))
-    
+        keys.update(k for k in dir(local_config) if not k.startswith("_"))
+
     return keys
 
+
 # Export commonly used functions
-__all__ = ['get_config', 'get_required_config', 'list_config_keys']
+__all__ = ["get_config", "get_required_config", "list_config_keys"]

--- a/app/get_stop_names.py
+++ b/app/get_stop_names.py
@@ -4,35 +4,32 @@ from pathlib import Path
 from datetime import timedelta
 import json
 import logging
-from logging.config import dictConfig
 
 from config import get_config
 
 # Get configuration
-API_CONFIG = get_config('API_CONFIG')
-STOPS_API_URL = API_CONFIG['STIB_STOPS_API_URL']
-API_KEY = get_config('STIB_API_KEY')
-CACHE_DIR = get_config('CACHE_DIR')
+API_CONFIG = get_config("API_CONFIG")
+STOPS_API_URL = API_CONFIG["STIB_STOPS_API_URL"]
+API_KEY = get_config("STIB_API_KEY")
+CACHE_DIR = get_config("CACHE_DIR")
 STOPS_CACHE_FILE = CACHE_DIR / "stops.json"
-CACHE_DURATION = get_config('CACHE_DURATION')
+CACHE_DURATION = get_config("CACHE_DURATION")
 
-# Setup logging using configuration
-logging_config = get_config('LOGGING_CONFIG')
-dictConfig(logging_config)
 
 # Get logger
-logger = logging.getLogger('stops')
+logger = logging.getLogger("stops")
+
 
 def load_cached_stops():
     """Load stop names from cache file"""
     if STOPS_CACHE_FILE.exists():
         try:
-            with open(STOPS_CACHE_FILE, 'r', encoding='utf-8') as f:
+            with open(STOPS_CACHE_FILE, "r", encoding="utf-8") as f:
                 return json.load(f)
         except FileNotFoundError:
             logger.warning("Stops cache file not found, creating empty cache")
             # Create empty cache file
-            with open(STOPS_CACHE_FILE, 'w', encoding='utf-8') as f:
+            with open(STOPS_CACHE_FILE, "w", encoding="utf-8") as f:
                 json.dump({}, f)
             logger.info("Created empty stops cache file")
             return {}
@@ -40,17 +37,20 @@ def load_cached_stops():
             logger.error(f"Error loading stops cache: {e}", exc_info=True)
     return {}
 
+
 # Load cached stops at startup
 cached_stops = load_cached_stops()
 logger.debug(f"Loaded {len(cached_stops)} stops from cache for STIB")
 
+
 def save_cached_stops(stops_data):
     """Save stop names to cache file"""
     try:
-        with open(STOPS_CACHE_FILE, 'w', encoding='utf-8') as f:
+        with open(STOPS_CACHE_FILE, "w", encoding="utf-8") as f:
             json.dump(stops_data, f, ensure_ascii=False, indent=2)
     except Exception as e:
         logger.error(f"Error saving stops cache: {e}", exc_info=True)
+
 
 def get_stop_names(stop_ids):
     """Fetch stop names and coordinates for a list of stop IDs, using cache when possible"""
@@ -62,50 +62,52 @@ def get_stop_names(stop_ids):
     if stops_to_fetch:
         logger.info(f"Fetching {len(stops_to_fetch)} new stop details")
         for stop_id in stops_to_fetch:
-            params = {
-                'where': f'id="{stop_id}"',
-                'limit': 1,
-                'apikey': API_KEY
-            }
+            params = {"where": f'id="{stop_id}"', "limit": 1, "apikey": API_KEY}
 
             try:
                 response = requests.get(STOPS_API_URL, params=params)
-                logger.debug(f"Stop details API Response status for {stop_id}: {response.status_code}")
-                
+                logger.debug(
+                    f"Stop details API Response status for {stop_id}: {response.status_code}"
+                )
+
                 if response.status_code != 200:
                     logger.warning(f"Stop details API Response text: {response.text}")
 
                 response.raise_for_status()
                 data = response.json()
 
-                if data['results']:
-                    stop_data = data['results'][0]
-                    name_data = json.loads(stop_data['name'])
+                if data["results"]:
+                    stop_data = data["results"][0]
+                    name_data = json.loads(stop_data["name"])
 
                     # Extract coordinates from the response
-                    gps_coords = json.loads(stop_data.get('gpscoordinates', '{}'))
+                    gps_coords = json.loads(stop_data.get("gpscoordinates", "{}"))
                     coordinates = {
-                        'lat': gps_coords.get('latitude', None),
-                        'lon': gps_coords.get('longitude', None)
+                        "lat": gps_coords.get("latitude", None),
+                        "lon": gps_coords.get("longitude", None),
                     }
 
                     cached_stops[stop_id] = {
-                        'name': name_data['fr'],
-                        'coordinates': coordinates
+                        "name": name_data["fr"],
+                        "coordinates": coordinates,
                     }
-                    logger.debug(f"Added stop {stop_id} to cache: {cached_stops[stop_id]}")
+                    logger.debug(
+                        f"Added stop {stop_id} to cache: {cached_stops[stop_id]}"
+                    )
                 else:
                     logger.warning(f"No data found for stop ID: {stop_id}")
                     cached_stops[stop_id] = {
-                        'name': stop_id,
-                        'coordinates': {'lat': None, 'lon': None}
+                        "name": stop_id,
+                        "coordinates": {"lat": None, "lon": None},
                     }
 
             except Exception as e:
-                logger.error(f"Error fetching stop details for {stop_id}: {e}", exc_info=True)
+                logger.error(
+                    f"Error fetching stop details for {stop_id}: {e}", exc_info=True
+                )
                 cached_stops[stop_id] = {
-                    'name': stop_id,
-                    'coordinates': {'lat': None, 'lon': None}
+                    "name": stop_id,
+                    "coordinates": {"lat": None, "lon": None},
                 }
 
         # Save updated cache
@@ -113,7 +115,9 @@ def get_stop_names(stop_ids):
         logger.info("Saved updated stops cache")
 
     # Return requested stop details from cache
-    return {stop_id: cached_stops.get(stop_id, {'name': stop_id, 'coordinates': {'lat': None, 'lon': None}})
-            for stop_id in stop_ids}
-
-
+    return {
+        stop_id: cached_stops.get(
+            stop_id, {"name": stop_id, "coordinates": {"lat": None, "lon": None}}
+        )
+        for stop_id in stop_ids
+    }

--- a/app/locate_vehicles.py
+++ b/app/locate_vehicles.py
@@ -9,21 +9,29 @@ import sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 try:
-    from app.validate_stops import validate_line_stops, load_route_shape, RouteVariant, Terminus, Stop
+    from app.validate_stops import (
+        validate_line_stops,
+        load_route_shape,
+        RouteVariant,
+        Terminus,
+        Stop,
+    )
 except ImportError:
-    from validate_stops import validate_line_stops, load_route_shape, RouteVariant, Terminus, Stop
+    from validate_stops import (
+        validate_line_stops,
+        load_route_shape,
+        RouteVariant,
+        Terminus,
+        Stop,
+    )
 
 from math import sqrt, sin, cos, radians, asin, degrees
 import math
 from config import get_config
-from logging.config import dictConfig
 
-# Setup logging using configuration
-logging_config = get_config('LOGGING_CONFIG')
-dictConfig(logging_config)
 
 # Get logger
-logger = logging.getLogger('locate_vehicles')
+logger = logging.getLogger("locate_vehicles")
 
 
 @dataclass
@@ -42,21 +50,23 @@ class VehiclePosition:
     def to_dict(self):
         """Convert the VehiclePosition object to a dictionary for JSON serialization"""
         return {
-            'line': self.line,
-            'direction': self.direction,
-            'current_segment': self.current_segment,
-            'distance_to_next': self.distance_to_next,
-            'segment_length': self.segment_length,
-            'is_valid': self.is_valid,
-            'interpolated_position': self.interpolated_position,
-            'bearing': self.bearing
+            "line": self.line,
+            "direction": self.direction,
+            "current_segment": self.current_segment,
+            "distance_to_next": self.distance_to_next,
+            "segment_length": self.segment_length,
+            "is_valid": self.is_valid,
+            "interpolated_position": self.interpolated_position,
+            "bearing": self.bearing,
         }
 
     def __json__(self):
         return self.to_dict()
 
 
-def haversine_distance(point1: Tuple[float, float], point2: Tuple[float, float]) -> float:
+def haversine_distance(
+    point1: Tuple[float, float], point2: Tuple[float, float]
+) -> float:
     """
     Calculate the distance between two points on Earth using the Haversine formula.
     Points are (lat, lon) tuples.
@@ -65,65 +75,71 @@ def haversine_distance(point1: Tuple[float, float], point2: Tuple[float, float])
     # Validate inputs
     if not all(isinstance(x, (int, float)) for x in point1 + point2):
         raise ValueError(f"Invalid coordinates: point1={point1}, point2={point2}")
-        
+
     lat1, lon1 = point1
     lat2, lon2 = point2
-    
+
     R = 6371000  # Earth's radius in meters
-    
+
     # Convert to radians
     lat1, lon1, lat2, lon2 = map(radians, [lat1, lon1, lat2, lon2])
-    
+
     # Haversine formula
     dlat = lat2 - lat1
     dlon = lon2 - lon1
-    a = sin(dlat/2)**2 + cos(lat1) * cos(lat2) * sin(dlon/2)**2
+    a = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlon / 2) ** 2
     c = 2 * asin(sqrt(a))
-    
+
     return R * c
 
 
-def calculate_segment_distance(shape_coords: List[List[float]], 
-                             start_idx: int, 
-                             end_idx: int) -> float:
+def calculate_segment_distance(
+    shape_coords: List[List[float]], start_idx: int, end_idx: int
+) -> float:
     """
     Calculate the total distance along a shape between two points.
     """
     total_distance = 0
     for i in range(start_idx, end_idx):
-        point1 = (shape_coords[i][1], shape_coords[i][0])    # lat, lon
-        point2 = (shape_coords[i+1][1], shape_coords[i+1][0])  # lat, lon
+        point1 = (shape_coords[i][1], shape_coords[i][0])  # lat, lon
+        point2 = (shape_coords[i + 1][1], shape_coords[i + 1][0])  # lat, lon
         total_distance += haversine_distance(point1, point2)
     return total_distance
 
 
-def find_stop_in_shape(stop_coords: Tuple[float, float], 
-                      shape_coords: List[List[float]], 
-                      max_distance: float = 50) -> Optional[int]:
+def find_stop_in_shape(
+    stop_coords: Tuple[float, float],
+    shape_coords: List[List[float]],
+    max_distance: float = 50,
+) -> Optional[int]:
     """
     Find the closest point in the shape to a stop.
     Returns the index in shape_coords or None if no close match found.
     stop_coords is (lat, lon)
     shape_coords is list of [lon, lat] pairs
     """
-    min_distance = float('inf')
+    min_distance = float("inf")
     best_idx = None
-    
+
     # Validate stop coordinates
     if not stop_coords or len(stop_coords) != 2:
         logger.error(f"Invalid stop coordinates: {stop_coords}")
         return None
-        
+
     for i, coord in enumerate(shape_coords):
         try:
             # Validate shape coordinates
-            if not coord or len(coord) != 2 or not all(isinstance(x, (int, float)) for x in coord):
+            if (
+                not coord
+                or len(coord) != 2
+                or not all(isinstance(x, (int, float)) for x in coord)
+            ):
                 logger.error(f"Invalid shape coordinate at index {i}: {coord}")
                 continue
-                
+
             # Shape coordinates are [lon, lat], need to swap for comparison
             shape_point = (coord[1], coord[0])  # Convert to (lat, lon)
-            
+
             try:
                 dist = haversine_distance(stop_coords, shape_point)
                 if dist < min_distance:
@@ -132,24 +148,27 @@ def find_stop_in_shape(stop_coords: Tuple[float, float],
             except ValueError as e:
                 logger.error(f"Distance calculation failed at index {i}: {e}")
                 continue
-                
+
         except (IndexError, TypeError) as e:
             logger.error(f"Invalid coordinate at index {i}: {coord}")
             logger.error(f"Error: {str(e)}")
             continue
-    
+
     if min_distance <= max_distance:
         return best_idx
     return None
 
-def validate_segment(from_stop: Stop, 
-                    to_stop: Stop, 
-                    line: str,
-                    direction: str,
-                    distance_to_next: float,
-                    route_variant: RouteVariant,
-                    raw_data: Dict,
-                    **kwargs) -> Optional[VehiclePosition]:
+
+def validate_segment(
+    from_stop: Stop,
+    to_stop: Stop,
+    line: str,
+    direction: str,
+    distance_to_next: float,
+    route_variant: RouteVariant,
+    raw_data: Dict,
+    **kwargs,
+) -> Optional[VehiclePosition]:
     """
     Validate a vehicle's position and calculate segment details.
     """
@@ -157,76 +176,91 @@ def validate_segment(from_stop: Stop,
         # Load shape coordinates for this specific direction
         shape_coords = load_route_shape(line, direction)
         if not shape_coords:
-            logger.error(f"No shape coordinates found for line {line} direction {direction}")
+            logger.error(
+                f"No shape coordinates found for line {line} direction {direction}"
+            )
             return None
 
         # Validate stop coordinates exist and have the expected structure
-        if (not from_stop.get('coordinates') or 
-            not isinstance(from_stop['coordinates'], dict) or
-            not to_stop.get('coordinates') or 
-            not isinstance(to_stop['coordinates'], dict)):
-            logger.error(f"Missing coordinates for stops: from={from_stop.get('name')}, to={to_stop.get('name')}")
+        if (
+            not from_stop.get("coordinates")
+            or not isinstance(from_stop["coordinates"], dict)
+            or not to_stop.get("coordinates")
+            or not isinstance(to_stop["coordinates"], dict)
+        ):
+            logger.error(
+                f"Missing coordinates for stops: from={from_stop.get('name')}, to={to_stop.get('name')}"
+            )
             return None
 
         # Validate lat/lon values exist
-        from_lat = from_stop['coordinates'].get('lat')
-        from_lon = from_stop['coordinates'].get('lon')
-        to_lat = to_stop['coordinates'].get('lat')
-        to_lon = to_stop['coordinates'].get('lon')
+        from_lat = from_stop["coordinates"].get("lat")
+        from_lon = from_stop["coordinates"].get("lon")
+        to_lat = to_stop["coordinates"].get("lat")
+        to_lon = to_stop["coordinates"].get("lon")
 
         if any(coord is None for coord in [from_lat, from_lon, to_lat, to_lon]):
-            logger.error(f"Line {line}: Missing lat/lon values for stops {from_stop['id']} -> {to_stop['id']}: from=({from_lat}, {from_lon}), to=({to_lat}, {to_lon})")
+            logger.error(
+                f"Line {line}: Missing lat/lon values for stops {from_stop['id']} -> {to_stop['id']}: from=({from_lat}, {from_lon}), to=({to_lat}, {to_lon})"
+            )
             return None
 
         # Create coordinate tuples only after validation
         from_coords = (from_lat, from_lon)
         to_coords = (to_lat, to_lon)
-        
+
         # Find stops in shape
         from_idx = find_stop_in_shape(from_coords, shape_coords)
         to_idx = find_stop_in_shape(to_coords, shape_coords)
-        
+
         if from_idx is None or to_idx is None:
-            logger.error(f"Could not locate stops in shape: {from_stop['name']} or {to_stop['name']}")
+            logger.error(
+                f"Could not locate stops in shape: {from_stop['name']} or {to_stop['name']}"
+            )
             return None
-        
+
         # Ensure correct order
         if from_idx > to_idx:
             from_idx, to_idx = to_idx, from_idx
-        
+
         # Calculate total segment distance
         segment_length = calculate_segment_distance(shape_coords, from_idx, to_idx)
-        
+
         # Extract shape segment
-        shape_segment = shape_coords[from_idx:to_idx + 1]
-        
+        shape_segment = shape_coords[from_idx : to_idx + 1]
+
         # Validate reported distance with 20% tolerance
         tolerance = 1.2  # Allow reported distance to be up to 20% longer
         is_valid = distance_to_next <= segment_length * tolerance
-        
+
         if not is_valid:
             logger.warning(
                 f"Reported distance ({distance_to_next:.0f}m) is significantly greater than "
                 f"segment length ({segment_length:.0f}m) between "
                 f"{from_stop['name']} and {to_stop['name']}"
             )
-        
+
         return VehiclePosition(
             line=line,
             direction=direction,
-            current_segment=(from_stop['id'], to_stop['id']),
+            current_segment=(from_stop["id"], to_stop["id"]),
             distance_to_next=min(distance_to_next, segment_length),  # Cap the distance
             segment_length=segment_length,
             shape_segment=shape_segment,
-            raw_data=raw_data
+            raw_data=raw_data,
         )
     except Exception as e:
         import traceback
+
         logger.error(f"Error validating segment: {str(e)}")
         logger.error(f"Full traceback:\n{traceback.format_exc()}")
         logger.error(f"Input data:")
-        logger.error(f"  From stop: {from_stop['name']} (ID: {from_stop['id']}) at {from_stop['coordinates']}")
-        logger.error(f"  To stop: {to_stop['name']} (ID: {to_stop['id']}) at {to_stop['coordinates']}")
+        logger.error(
+            f"  From stop: {from_stop['name']} (ID: {from_stop['id']}) at {from_stop['coordinates']}"
+        )
+        logger.error(
+            f"  To stop: {to_stop['name']} (ID: {to_stop['id']}) at {to_stop['coordinates']}"
+        )
         logger.error(f"  Distance to next: {distance_to_next}m")
         logger.error(f"  Line: {line}, Direction: {direction}")
         logger.error(f"  Shape coords length: {len(shape_coords)}")
@@ -235,28 +269,29 @@ def validate_segment(from_stop: Stop,
         return None
 
 
-def find_vehicle_segment(vehicle_data: Dict, 
-                        route_variant: RouteVariant,
-                        shape_coords: List[List[float]],
-                        line: str,
-                        direction: str) -> Optional[VehiclePosition]:
+def find_vehicle_segment(
+    vehicle_data: Dict,
+    route_variant: RouteVariant,
+    shape_coords: List[List[float]],
+    line: str,
+    direction: str,
+) -> Optional[VehiclePosition]:
     """
     Find which segment a vehicle is on and validate its position
     """
-    next_stop_id = vehicle_data['next_stop']
-    distance = vehicle_data['distance']
-    
+    next_stop_id = vehicle_data["next_stop"]
+    distance = vehicle_data["distance"]
+
     try:
         next_stop_index = next(
-            i for i, stop in enumerate(route_variant.stops)
-            if stop.id == next_stop_id
+            i for i, stop in enumerate(route_variant.stops) if stop.id == next_stop_id
         )
-        
+
         # The previous stop is where the vehicle is coming from
         if next_stop_index > 0:
             from_stop = route_variant.stops[next_stop_index - 1]
             to_stop = route_variant.stops[next_stop_index]
-            
+
             return validate_segment(
                 from_stop=from_stop,
                 to_stop=to_stop,
@@ -264,12 +299,14 @@ def find_vehicle_segment(vehicle_data: Dict,
                 direction=direction,
                 distance_to_next=distance,
                 route_variant=route_variant,
-                raw_data=vehicle_data
+                raw_data=vehicle_data,
             )
         else:
-            logger.warning(f"Vehicle reporting next stop {next_stop_id} which is first stop in route")
+            logger.warning(
+                f"Vehicle reporting next stop {next_stop_id} which is first stop in route"
+            )
             return None
-            
+
     except StopIteration:
         logger.error(f"Next stop {next_stop_id} not found in route stop list")
         return None
@@ -281,140 +318,155 @@ async def get_terminus_stops(line: str) -> Dict[str, Terminus]:
     """
     variants = await validate_line_stops(line)
     terminus_map = {}
-    
+
     # First, get the known terminus stops
     for variant in variants:
         if not variant.stops:
             continue
-            
+
         terminus = variant.stops[-1]
-        terminus_map[terminus['id']] = Terminus(
-            stop_id=terminus['id'],
-            stop_name=terminus['name'],
+        terminus_map[terminus["id"]] = Terminus(
+            stop_id=terminus["id"],
+            stop_name=terminus["name"],
             direction=variant.direction,
-            destination=variant.destination
+            destination=variant.destination,
         )
         logger.debug(f"\nLine {line} {variant.direction}:")
         logger.debug(f"  Terminus: {terminus['name']} (ID: {terminus['id']})")
         logger.debug(f"  Heading to: {variant.destination['fr']}")
-    
+
     return terminus_map
 
 
 async def process_vehicle_positions(positions_data: Dict) -> List[VehiclePosition]:
     """Process raw vehicle positions data into Vehicle objects"""
     vehicles = []
-    
+
     for line, directions in positions_data.items():
         try:
             # Get terminus data for this line
             terminus_data = await get_terminus_stops(line)
             logger.debug(f"\nLine {line}:")
-            
+
             # Get route variants for this line
             route_variants = await validate_line_stops(line)
             if not route_variants:
                 logger.error(f"No route variants found for line {line}")
                 continue
-                
+
             # Process each direction's vehicles
             for terminus_id, vehicles_list in directions.items():
                 # Try to determine direction from terminus data
                 terminus_info = terminus_data.get(terminus_id)
                 direction = None
-                
+
                 if terminus_info:
-                    logger.debug(f"  Terminus: {terminus_info.stop_name} (ID: {terminus_info.stop_id})")
+                    logger.debug(
+                        f"  Terminus: {terminus_info.stop_name} (ID: {terminus_info.stop_id})"
+                    )
                     logger.debug(f"  Heading to: {terminus_info.destination['fr']}")
                     direction = terminus_info.direction
                 else:
                     # If terminus not found, try to determine direction from next stops
                     for vehicle_data in vehicles_list:
-                        next_stop = vehicle_data['next_stop']
+                        next_stop = vehicle_data["next_stop"]
                         # First try with original stop ID
                         for variant in route_variants:
-                            if any(stop['id'] == next_stop for stop in variant.stops):
+                            if any(stop["id"] == next_stop for stop in variant.stops):
                                 direction = variant.direction
                                 break
-                                
+
                         # If not found, try with suffixes
                         if not direction:
-                            for suffix in ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']:
+                            for suffix in ["A", "B", "C", "D", "E", "F", "G", "H"]:
                                 next_stop_with_suffix = f"{next_stop}{suffix}"
                                 for variant in route_variants:
-                                    if any(stop['id'] == next_stop_with_suffix for stop in variant.stops):
+                                    if any(
+                                        stop["id"] == next_stop_with_suffix
+                                        for stop in variant.stops
+                                    ):
                                         direction = variant.direction
                                         break
                                 if direction:
                                     break
-                                    
+
                         if direction:
                             break
-                    
+
                     if not direction:
-                        logger.warning(f"Unknown direction for terminus. "
-                                     f"Terminus ID: {terminus_id}. "
-                                     f"Available terminus data: {terminus_data}. "
-                                     f"Line {line} direction data: {directions}")
+                        logger.warning(
+                            f"Unknown direction for terminus. "
+                            f"Terminus ID: {terminus_id}. "
+                            f"Available terminus data: {terminus_data}. "
+                            f"Line {line} direction data: {directions}"
+                        )
                         continue
                 # Process vehicles for this direction
                 for vehicle_data in vehicles_list:
-                    next_stop_id = vehicle_data['next_stop']
-                    
+                    next_stop_id = vehicle_data["next_stop"]
+
                     # Find the route variant containing this stop
                     route_variant = None
                     # Try finding route variant with original stop ID
                     for variant in route_variants:
-                        if any(stop['id'] == next_stop_id for stop in variant.stops):
+                        if any(stop["id"] == next_stop_id for stop in variant.stops):
                             route_variant = variant
                             break
-                            
+
                     # If not found, try with suffixes
                     if not route_variant:
-                        suffixes = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']
+                        suffixes = ["A", "B", "C", "D", "E", "F", "G", "H"]
                         for suffix in suffixes:
                             stop_id_with_suffix = f"{next_stop_id}{suffix}"
                             for variant in route_variants:
-                                if any(stop['id'] == stop_id_with_suffix for stop in variant.stops):
+                                if any(
+                                    stop["id"] == stop_id_with_suffix
+                                    for stop in variant.stops
+                                ):
                                     route_variant = variant
                                     break
                             if route_variant:
                                 break
-                    
+
                     if not route_variant:
-                        logger.error(f"No route variant found containing stop {next_stop_id} (or with suffixes) for line {line}")
+                        logger.error(
+                            f"No route variant found containing stop {next_stop_id} (or with suffixes) for line {line}"
+                        )
                         continue
-                        
+
                     try:
                         # Try original ID first
                         try:
                             next_stop_index = next(
-                                i for i, stop in enumerate(route_variant.stops)
-                                if stop['id'] == next_stop_id
+                                i
+                                for i, stop in enumerate(route_variant.stops)
+                                if stop["id"] == next_stop_id
                             )
                         except StopIteration:
                             # Try with suffixes
                             found = False
-                            for suffix in ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']:
+                            for suffix in ["A", "B", "C", "D", "E", "F", "G", "H"]:
                                 try:
                                     next_stop_index = next(
-                                        i for i, stop in enumerate(route_variant.stops)
-                                        if stop['id'] == f"{next_stop_id}{suffix}"
+                                        i
+                                        for i, stop in enumerate(route_variant.stops)
+                                        if stop["id"] == f"{next_stop_id}{suffix}"
                                     )
                                     found = True
                                     break
                                 except StopIteration:
                                     continue
                             if not found:
-                                raise StopIteration(f"Stop {next_stop_id} not found with any suffix")
-                        
+                                raise StopIteration(
+                                    f"Stop {next_stop_id} not found with any suffix"
+                                )
+
                         if next_stop_index > 0:
                             from_stop = route_variant.stops[next_stop_index - 1]
                             to_stop = route_variant.stops[next_stop_index]
-                            
+
                             # Load shape coordinates
                             shape_coords = load_route_shape(line)
-                            
 
                             # Create vehicle position
                             vehicle = validate_segment(
@@ -422,28 +474,31 @@ async def process_vehicle_positions(positions_data: Dict) -> List[VehiclePositio
                                 to_stop=to_stop,
                                 line=line,
                                 direction=direction,
-                                distance_to_next=vehicle_data['distance'],
+                                distance_to_next=vehicle_data["distance"],
                                 route_variant=route_variant,
-                                next_stop_coords=to_stop['coordinates'],
-                                raw_data=vehicle_data
+                                next_stop_coords=to_stop["coordinates"],
+                                raw_data=vehicle_data,
                             )
-                            
+
                             if vehicle:
                                 vehicles.append(vehicle)
-                                
+
                     except StopIteration:
-                        logger.error(f"Next stop {next_stop_id} not found in route stop list")
+                        logger.error(
+                            f"Next stop {next_stop_id} not found in route stop list"
+                        )
                         continue
                     except Exception as e:
                         logger.error(f"Error processing vehicle: {str(e)}")
                         continue
-                    
+
         except Exception as e:
             logger.error(f"Error processing line {line}: {str(e)}")
             import traceback
+
             logger.error(f"Error processing line {line}: {traceback.format_exc()}")
             continue
-            
+
     return vehicles
 
 
@@ -454,34 +509,37 @@ def interpolate_position(vehicle: VehiclePosition) -> Optional[Tuple[float, floa
     """
     if not vehicle.is_valid or not vehicle.shape_segment:
         return None
-        
+
     # Distance from start of segment
     distance_from_start = vehicle.segment_length - vehicle.distance_to_next
-    
+
     # Walk along shape until we find our position
     current_distance = 0
     for i in range(len(vehicle.shape_segment) - 1):
-        point1 = (vehicle.shape_segment[i][1], vehicle.shape_segment[i][0])     # lat, lon
-        point2 = (vehicle.shape_segment[i+1][1], vehicle.shape_segment[i+1][0]) # lat, lon
-        
+        point1 = (vehicle.shape_segment[i][1], vehicle.shape_segment[i][0])  # lat, lon
+        point2 = (
+            vehicle.shape_segment[i + 1][1],
+            vehicle.shape_segment[i + 1][0],
+        )  # lat, lon
+
         segment_distance = haversine_distance(point1, point2)
         next_distance = current_distance + segment_distance
-        
+
         if next_distance >= distance_from_start:
             # Our position is on this mini-segment
             fraction = (distance_from_start - current_distance) / segment_distance
-            
+
             # Linear interpolation
             lat = point1[0] + fraction * (point2[0] - point1[0])
             lon = point1[1] + fraction * (point2[1] - point1[1])
-            
+
             # Calculate bearing
             vehicle.bearing = calculate_bearing(lat, lon, point2[0], point2[1])
-            
+
             return (lat, lon)
-            
+
         current_distance = next_distance
-    
+
     # If we get here, we're at the end of the segment
     last_point = vehicle.shape_segment[-1]
     return (last_point[1], last_point[0])  # Return last point instead of None
@@ -494,30 +552,71 @@ def calculate_bearing(lat1, lon1, lat2, lon2):
     lon1 = math.radians(lon1)
     lat2 = math.radians(lat2)
     lon2 = math.radians(lon2)
-    
+
     # Calculate bearing
     d_lon = lon2 - lon1
     y = math.sin(d_lon) * math.cos(lat2)
-    x = math.cos(lat1) * math.sin(lat2) - math.sin(lat1) * math.cos(lat2) * math.cos(d_lon)
+    x = math.cos(lat1) * math.sin(lat2) - math.sin(lat1) * math.cos(lat2) * math.cos(
+        d_lon
+    )
     bearing = math.degrees(math.atan2(y, x))
-    
+
     # Normalize to 0-360
     return (bearing + 360) % 360
 
+
 if __name__ == "__main__":
     # Example vehicle positions data
-    example_positions = {"56": {"2378": [{"distance": 32, "next_stop": "6190"}, {"distance": 70, "next_stop": "1062"}], "6465": [{"distance": 0, "next_stop": "3080"}, {"distance": 0, "next_stop": "6461"}, {"distance": 0, "next_stop": "2379"}, {"distance": 0, "next_stop": "2379"}]}, "59": {"3125": [{"distance": 358, "next_stop": "3099"}, {"distance": 40, "next_stop": "6465"}], "3130": [{"distance": 0, "next_stop": "3172"}, {"distance": 359, "next_stop": "3155"}, {"distance": 52, "next_stop": "9296"}, {"distance": 0, "next_stop": "3125"}]}, "64": {"3134": [{"distance": 75, "next_stop": "3185"}, {"distance": 6, "next_stop": "5299"}, {"distance": 258, "next_stop": "1729"}], "4952": [{"distance": 50, "next_stop": "1162"}, {"distance": 49, "next_stop": "2915"}]}}
-    
+    example_positions = {
+        "56": {
+            "2378": [
+                {"distance": 32, "next_stop": "6190"},
+                {"distance": 70, "next_stop": "1062"},
+            ],
+            "6465": [
+                {"distance": 0, "next_stop": "3080"},
+                {"distance": 0, "next_stop": "6461"},
+                {"distance": 0, "next_stop": "2379"},
+                {"distance": 0, "next_stop": "2379"},
+            ],
+        },
+        "59": {
+            "3125": [
+                {"distance": 358, "next_stop": "3099"},
+                {"distance": 40, "next_stop": "6465"},
+            ],
+            "3130": [
+                {"distance": 0, "next_stop": "3172"},
+                {"distance": 359, "next_stop": "3155"},
+                {"distance": 52, "next_stop": "9296"},
+                {"distance": 0, "next_stop": "3125"},
+            ],
+        },
+        "64": {
+            "3134": [
+                {"distance": 75, "next_stop": "3185"},
+                {"distance": 6, "next_stop": "5299"},
+                {"distance": 258, "next_stop": "1729"},
+            ],
+            "4952": [
+                {"distance": 50, "next_stop": "1162"},
+                {"distance": 49, "next_stop": "2915"},
+            ],
+        },
+    }
+
     vehicles = process_vehicle_positions(example_positions)
-    
+
     logger.info("\n=== Vehicle Positions ===")
     for vehicle in vehicles:
         logger.info(f"\nLine {vehicle.line} ({vehicle.direction})")
-        logger.info(f"  Between stops: {vehicle.current_segment[0]} → {vehicle.current_segment[1]}")
+        logger.info(
+            f"  Between stops: {vehicle.current_segment[0]} → {vehicle.current_segment[1]}"
+        )
         logger.info(f"  Distance to next stop: {vehicle.distance_to_next}m")
         logger.info(f"  Segment length: {vehicle.segment_length:.0f}m")
         logger.info(f"  Valid position: {vehicle.is_valid}")
-        
+
         if vehicle.is_valid:
             position = interpolate_position(vehicle)
             if position:

--- a/app/main.py
+++ b/app/main.py
@@ -18,7 +18,6 @@ from validate_stops import validate_line_stops
 from locate_vehicles import process_vehicle_positions
 from collections import defaultdict
 import logging
-from logging.config import dictConfig
 from utils import RateLimiter, get_client
 from flask import jsonify
 from transit_providers import PROVIDERS, get_provider_path, get_provider_from_path
@@ -31,10 +30,6 @@ import secrets
 from functools import wraps
 from transit_providers.config import get_provider_config
 from functools import lru_cache
-
-# Setup logging using configuration
-logging_config = get_config('LOGGING_CONFIG')
-dictConfig(logging_config)
 
 # Get loggers
 logger = logging.getLogger("main")

--- a/app/routes.py
+++ b/app/routes.py
@@ -9,25 +9,21 @@ from get_stop_names import get_stop_names
 import logging
 from utils import RateLimiter, get_client
 from config import get_config
-from logging.config import dictConfig
 
-# Setup logging using configuration
-logging_config = get_config('LOGGING_CONFIG')
-dictConfig(logging_config)
 
 # Get logger
-logger = logging.getLogger('routes')
+logger = logging.getLogger("routes")
 
 # Create cache directories for shapefiles and stops
-SHAPES_CACHE_DIR = get_config('CACHE_DIR') / "shapes"
-STOPS_CACHE_DIR = get_config('CACHE_DIR') / "stops"
+SHAPES_CACHE_DIR = get_config("CACHE_DIR") / "shapes"
+STOPS_CACHE_DIR = get_config("CACHE_DIR") / "stops"
 SHAPES_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 STOPS_CACHE_DIR.mkdir(parents=True, exist_ok=True)
 
-CACHE_DURATION = get_config('CACHE_DURATION')
-API_KEY = get_config('STIB_API_KEY')
+CACHE_DURATION = get_config("CACHE_DURATION")
+API_KEY = get_config("STIB_API_KEY")
 
-RATE_LIMIT_DELAY = get_config('RATE_LIMIT_DELAY')
+RATE_LIMIT_DELAY = get_config("RATE_LIMIT_DELAY")
 
 # Keep track of last API call time
 last_api_call = datetime.min
@@ -37,287 +33,310 @@ rate_limiter = RateLimiter()
 
 # Variante 2: goint to city centre, variante 1: going to the suburbs
 
+
 def load_cached_shape(line: str) -> tuple[List[Dict], bool]:
     """Load shapefile from cache if it exists and is not expired"""
     cache_file = SHAPES_CACHE_DIR / f"line_{line}.json"
-    
+
     logger.debug(f"Checking cache for line {line} at {cache_file}")
-    
+
     if cache_file.exists():
         try:
-            with open(cache_file, 'r') as f:
+            with open(cache_file, "r") as f:
                 cache_data = json.load(f)
-                
+
             # Check if cache is expired based on date_fin
             current_date = datetime.now().date()
-            cache_expiry = datetime.strptime(cache_data['date_fin'], '%d/%m/%Y').date()
-            
+            cache_expiry = datetime.strptime(cache_data["date_fin"], "%d/%m/%Y").date()
+
             logger.debug(f"Cache found for line {line}:")
             logger.debug(f"  Current date: {current_date}")
             logger.debug(f"  Cache expiry: {cache_expiry}")
-            
+
             if current_date > cache_expiry:
                 logger.debug(f"  Cache expired")
                 return [], True
-                
+
             logger.debug(f"  Cache valid")
-            return cache_data['variants'], False
+            return cache_data["variants"], False
         except (json.JSONDecodeError, KeyError) as e:
             logger.error(f"Error reading cache for line {line}: {e}")
             return [], True
-    
+
     logger.debug(f"No cache file found for line {line}")
     return [], True
+
 
 def save_shape_to_cache(line: str, variants: List[Dict]) -> None:
     """Save shapefile data to cache"""
     cache_file = SHAPES_CACHE_DIR / f"line_{line}.json"
-    
+
     logger.info(f"Saving shape data to cache for line {line}")
     logger.debug(f"  Variants: {len(variants)}")
-    
+
     # Find the latest date_fin among all variants
-    latest_date_fin = max(v['date_fin'] for v in variants)
+    latest_date_fin = max(v["date_fin"] for v in variants)
     logger.debug(f"  Cache will expire on: {latest_date_fin}")
-    
+
     cache_data = {
-        'variants': variants,
-        'date_fin': latest_date_fin,
-        'cached_at': datetime.now().isoformat()
+        "variants": variants,
+        "date_fin": latest_date_fin,
+        "cached_at": datetime.now().isoformat(),
     }
-    
+
     try:
-        with open(cache_file, 'w') as f:
+        with open(cache_file, "w") as f:
             json.dump(cache_data, f)
         logger.debug(f"Successfully saved cache for line {line}")
     except Exception as e:
         import traceback
-        logger.error(f"Error saving cache for line {line}: {e}\n{traceback.format_exc()}")
+
+        logger.error(
+            f"Error saving cache for line {line}: {e}\n{traceback.format_exc()}"
+        )
+
 
 async def get_route_shape(line: str) -> List[Dict]:
     """Get route shape for a line, including all variants"""
     logger.debug(f"\n=== Starting shape fetch for line {line} ===")
-    
+
     cached_variants, should_refresh = load_cached_shape(line)
     if cached_variants and not should_refresh:
         return cached_variants
-        
+
     try:
         # Format line number to match API expectations
-        formatted_line = f"{int(line):03}b" # For bus lines
-        formatted_line_fallback = f"{int(line):03}t" # For tram lines
-        formatted_line_fallback_2 = f"{int(line):03}m" # For metro lines
+        formatted_line = f"{int(line):03}b"  # For bus lines
+        formatted_line_fallback = f"{int(line):03}t"  # For tram lines
+        formatted_line_fallback_2 = f"{int(line):03}m"  # For metro lines
         url = "https://stibmivb.opendatasoft.com/api/explore/v2.1/catalog/datasets/shapefiles-production/records"
         params = {
-            'where': f'ligne="{formatted_line}" or ligne="{formatted_line_fallback}" or ligne="{formatted_line_fallback_2}"',
-            'limit': 20,
-            'apikey': API_KEY
+            "where": f'ligne="{formatted_line}" or ligne="{formatted_line_fallback}" or ligne="{formatted_line_fallback_2}"',
+            "limit": 20,
+            "apikey": API_KEY,
         }
-        
+
         logger.debug(f"Making API request for line {line}")
-        
+
         async with await get_client() as client:
             response = await client.get(url, params=params)
             # Update rate limits from response headers
             rate_limiter.update_from_headers(response.headers)
-            
+
             logger.debug(f"API Response status: {response.status_code}")
-            
+
             if response.status_code != 200:
                 logger.error(f"Error response content: {response.text}")
             response.raise_for_status()
-            
+
             data = response.json()
             logger.debug(f"API returned {len(data.get('results', []))} results")
-            
+
             variants = []
-            for result in data['results']:
+            for result in data["results"]:
                 variant_data = {
-                    'variante': result['variante'],
-                    'date_debut': result['date_debut'],
-                    'date_fin': result['date_fin'],
-                    'coordinates': result['geo_shape']['geometry']['coordinates']
+                    "variante": result["variante"],
+                    "date_debut": result["date_debut"],
+                    "date_fin": result["date_fin"],
+                    "coordinates": result["geo_shape"]["geometry"]["coordinates"],
                 }
-                logger.debug(f"  Found variant {variant_data['variante']}: "
-                      f"{len(variant_data['coordinates'])} coordinates, "
-                      f"valid {variant_data['date_debut']} to {variant_data['date_fin']}")
+                logger.debug(
+                    f"  Found variant {variant_data['variante']}: "
+                    f"{len(variant_data['coordinates'])} coordinates, "
+                    f"valid {variant_data['date_debut']} to {variant_data['date_fin']}"
+                )
                 variants.append(variant_data)
-            
+
             if variants:
-                logger.debug(f"Successfully processed {len(variants)} variants for line {line}")
+                logger.debug(
+                    f"Successfully processed {len(variants)} variants for line {line}"
+                )
                 save_shape_to_cache(line, variants)
                 return variants
-                
+
             logger.warning(f"No shape data found for line {line}")
             logger.info(f"Full API Response: {response.text}")
             return cached_variants or []
 
     except httpx.HTTPStatusError as e:
         if e.response.status_code == 429:  # Too Many Requests
-            logger.warning(f"Rate limit hit for line {line}, using cached data if available")
-            if hasattr(e.response, 'headers'):
+            logger.warning(
+                f"Rate limit hit for line {line}, using cached data if available"
+            )
+            if hasattr(e.response, "headers"):
                 logger.info(f"Response headers: {e.response.headers}")
             return cached_variants
         else:
             logger.error(f"HTTP error fetching route shape for line {line}: {str(e)}")
-            logger.info(f"Response content: {e.response.text if hasattr(e, 'response') else 'No response content'}")
+            logger.info(
+                f"Response content: {e.response.text if hasattr(e, 'response') else 'No response content'}"
+            )
             return cached_variants or []
     except Exception as e:
         logger.error(f"Unexpected error fetching route shape for line {line}: {str(e)}")
         import traceback
+
         logger.error(f"Traceback: {traceback.format_exc()}")
         return cached_variants or []
     finally:
         logger.debug(f"=== Finished shape fetch for line {line} ===\n")
 
+
 def load_cached_stops(line: str) -> tuple[Dict, bool]:
     """Load stops from cache if it exists and is not expired"""
     cache_file = STOPS_CACHE_DIR / f"line_{line}_stops.json"
-    
+
     logger.debug(f"Checking stops cache for line {line} at {cache_file}")
-    
+
     if cache_file.exists():
         try:
-            with open(cache_file, 'r') as f:
+            with open(cache_file, "r") as f:
                 cache_data = json.load(f)
-                
-            cache_date = datetime.fromisoformat(cache_data['cached_at'])
+
+            cache_date = datetime.fromisoformat(cache_data["cached_at"])
             if datetime.now() - cache_date < CACHE_DURATION:
                 logger.debug(f"Using cached stops data for line {line}")
-                return cache_data['stops'], False
-                
+                return cache_data["stops"], False
+
             logger.info(f"Stops cache expired for line {line}")
-            return cache_data['stops'], True
+            return cache_data["stops"], True
         except Exception as e:
             logger.error(f"Error reading stops cache for line {line}: {e}")
             return {}, True
-    
+
     logger.info(f"No stops cache found for line {line}")
     return {}, True
+
 
 def save_stops_to_cache(line: str, stops_data: Dict) -> None:
     """Save stops data to cache"""
     cache_file = STOPS_CACHE_DIR / f"line_{line}_stops.json"
-    
-    cache_data = {
-        'stops': stops_data,
-        'cached_at': datetime.now().isoformat()
-    }
-    
+
+    cache_data = {"stops": stops_data, "cached_at": datetime.now().isoformat()}
+
     try:
-        with open(cache_file, 'w') as f:
+        with open(cache_file, "w") as f:
             json.dump(cache_data, f)
         logger.debug(f"Saved stops cache for line {line}")
     except Exception as e:
         import traceback
-        logger.error(f"Error saving stops cache for line {line}: {e}\n{traceback.format_exc()}")
+
+        logger.error(
+            f"Error saving stops cache for line {line}: {e}\n{traceback.format_exc()}"
+        )
+
 
 async def get_stops_for_line(line: str) -> Dict[str, List[Dict]]:
     """Get ordered stops for both directions of a line"""
     cached_stops, should_refresh = load_cached_stops(line)
     if not should_refresh:
         return cached_stops
-        
+
     url = "https://stibmivb.opendatasoft.com/api/explore/v2.1/catalog/datasets/stops-by-line-production/records"
-    params = {
-        'where': f'lineid={line}',
-        'limit': 20,
-        'apikey': API_KEY
-    }
-    
+    params = {"where": f"lineid={line}", "limit": 20, "apikey": API_KEY}
+
     try:
         async with await get_client() as client:
             response = await client.get(url, params=params)
             # Update rate limits from response headers
             rate_limiter.update_from_headers(response.headers)
-            
+
             data = response.json()
-            
+
             stops_by_direction = {
-                'City': [],    # Will match with variant 2
-                'Suburb': []   # Will match with variant 1
+                "City": [],  # Will match with variant 2
+                "Suburb": [],  # Will match with variant 1
             }
-            
-            for route in data['results']:
-                direction = route['direction']
+
+            for route in data["results"]:
+                direction = route["direction"]
                 try:
-                    destination = json.loads(route['destination'])
-                    points = json.loads(route['points'])
+                    destination = json.loads(route["destination"])
+                    points = json.loads(route["points"])
                 except json.JSONDecodeError as e:
                     logger.error(f"Error parsing JSON for {direction} direction: {e}")
                     logger.info(f"Raw destination: {route['destination']}")
                     logger.info(f"Raw points: {route['points']}")
                     continue
-                
+
                 logger.debug(f"Processing direction: {direction}")
                 logger.debug(f"Destination: {destination['fr']} / {destination['nl']}")
                 logger.debug(f"Found {len(points)} stops")
-                
+
                 stops_by_direction[direction] = {
-                    'stops': points,
-                    'destination': destination
+                    "stops": points,
+                    "destination": destination,
                 }
-            
+
             # Save to cache if we got valid data
             if any(stops_by_direction.values()):
                 save_stops_to_cache(line, stops_by_direction)
-            
+
             return stops_by_direction
-            
+
     except httpx.HTTPStatusError as e:
         if e.response.status_code == 429:  # Too Many Requests
-            logger.warning(f"Rate limit hit for stops on line {line}, using cached data if available")
+            logger.warning(
+                f"Rate limit hit for stops on line {line}, using cached data if available"
+            )
             return cached_stops
         else:
             logger.error(f"HTTP error fetching stops for line {line}: {str(e)}")
-            logger.info(f"Response content: {e.response.text if hasattr(e, 'response') else 'No response content'}")
-            return cached_stops or {'City': [], 'Suburb': []}
+            logger.info(
+                f"Response content: {e.response.text if hasattr(e, 'response') else 'No response content'}"
+            )
+            return cached_stops or {"City": [], "Suburb": []}
     except Exception as e:
         logger.error(f"Unexpected error fetching stops for line {line}: {str(e)}")
         import traceback
+
         logger.error(f"Traceback: {traceback.format_exc()}")
-        return cached_stops or {'City': [], 'Suburb': []}
+        return cached_stops or {"City": [], "Suburb": []}
+
 
 def match_stops_to_variants(shapes: Dict, stops_by_direction: Dict) -> Dict:
     """Match stops to the correct shape variants"""
     result = {}
-    
+
     for line, variants in shapes.items():
         result[line] = []
         for variant in variants:
-            direction = 'City' if variant['variante'] == 2 else 'Suburb'
+            direction = "City" if variant["variante"] == 2 else "Suburb"
             variant_data = {
-                'variante': variant['variante'],
-                'coordinates': variant['coordinates'],
-                'date_fin': variant['date_fin'],
-                'direction': direction,
-                'stops': stops_by_direction.get(direction, {}).get('stops', []),
-                'destination': stops_by_direction.get(direction, {}).get('destination', {})
+                "variante": variant["variante"],
+                "coordinates": variant["coordinates"],
+                "date_fin": variant["date_fin"],
+                "direction": direction,
+                "stops": stops_by_direction.get(direction, {}).get("stops", []),
+                "destination": stops_by_direction.get(direction, {}).get(
+                    "destination", {}
+                ),
             }
             result[line].append(variant_data)
-    
+
     return result
+
 
 async def get_route_data(line: str) -> Dict:
     """Get complete route data including shapes and stops"""
     shapes = await get_route_shape(line)
     stops_by_direction = await get_stops_for_line(line)
-    
+
     # Get all unique stop IDs from both directions
     all_stop_ids = set()
     for direction_data in stops_by_direction.values():
-        for stop in direction_data.get('stops', []):
-            all_stop_ids.add(stop['id'])
-    
+        for stop in direction_data.get("stops", []):
+            all_stop_ids.add(stop["id"])
+
     # Get stop details using existing function
     stop_details = get_stop_names(list(all_stop_ids))
-    
+
     # Add stop details to the data structure
     for direction, direction_data in stops_by_direction.items():
-        for stop in direction_data.get('stops', []):
-            stop_id = stop['id']
+        for stop in direction_data.get("stops", []):
+            stop_id = stop["id"]
             if stop_id in stop_details:
-                stop['name'] = stop_details[stop_id]['name']
-                stop['coordinates'] = stop_details[stop_id]['coordinates']
-    
+                stop["name"] = stop_details[stop_id]["name"]
+                stop["coordinates"] = stop_details[stop_id]["coordinates"]
+
     return {line: match_stops_to_variants({line: shapes}, stops_by_direction)[line]}

--- a/app/schedule_explorer/backend/gtfs_loader.py
+++ b/app/schedule_explorer/backend/gtfs_loader.py
@@ -17,20 +17,12 @@ import csv
 from .memory_util import check_memory_for_file
 
 
-def setup_logging():
-    """Configure logging for GTFS loader"""
-    logging_config = get_config("LOGGING_CONFIG")
-    # logging_config["log_dir"].mkdir(exist_ok=True)  # Removed: already created in start.py
-    logging.config.dictConfig(logging_config)
-    return logging.getLogger("schedule_explorer.gtfs")
-
-
 def bytes_to_mb(bytes: int, precision: int = 2) -> int:
     """Convert bytes to megabytes."""
     return round(bytes / (1024 * 1024), precision)
 
 
-logger = setup_logging()
+logger = logging.getLogger("schedule_explorer.gtfs_loader")
 
 
 @dataclass

--- a/app/schedule_explorer/backend/main.py
+++ b/app/schedule_explorer/backend/main.py
@@ -39,14 +39,6 @@ from .gtfs_loader import FlixbusFeed, load_feed
 DOWNLOAD_DIR = FilePath(os.environ["PROJECT_ROOT"]) / "downloads"
 
 
-# Configure logging
-def setup_logging():
-    """Configure logging for the schedule explorer backend"""
-    logging_config = get_config("LOGGING_CONFIG")
-    logging.config.dictConfig(logging_config)
-    return logging.getLogger("schedule_explorer")
-
-
 app = FastAPI(title="Schedule Explorer API")
 
 # Enable CORS
@@ -62,7 +54,7 @@ app.add_middleware(
 feed: Optional[FlixbusFeed] = None
 current_provider: Optional[str] = None
 available_providers: List[Provider] = []
-logger = setup_logging()
+logger = logging.getLogger("schedule_explorer.backend")
 db: Optional[MobilityAPI] = None
 
 

--- a/app/schedule_explorer/backend/memory_util.py
+++ b/app/schedule_explorer/backend/memory_util.py
@@ -1,18 +1,9 @@
 from pathlib import Path
 import psutil
 import logging
-from config import get_config
 
 
-def setup_logging():
-    """Configure logging for memory util"""
-    logging_config = get_config("LOGGING_CONFIG")
-    # logging_config["log_dir"].mkdir(exist_ok=True)  # Removed: already created in start.py
-    logging.config.dictConfig(logging_config)
-    return logging.getLogger("schedule_explorer.memory")
-
-
-logger = setup_logging()
+logger = logging.getLogger("schedule_explorer.memory")
 
 
 def check_memory_for_file(file_path: Path, safety_factor: float = 2.0) -> bool:

--- a/app/transit_providers/be/delijn/__init__.py
+++ b/app/transit_providers/be/delijn/__init__.py
@@ -8,18 +8,17 @@ from typing import Dict, Any, Callable, Awaitable, List
 from transit_providers.config import get_provider_config
 from config import get_config
 import logging
-from logging.config import dictConfig
-from transit_providers.nearest_stop import get_stop_by_name as generic_get_stop_by_name, get_cached_stops
+from transit_providers.nearest_stop import (
+    get_stop_by_name as generic_get_stop_by_name,
+    get_cached_stops,
+)
 from dataclasses import asdict
 from pathlib import Path
 from transit_providers import TransitProvider, register_provider
 
-# Setup logging using configuration
-logging_config = get_config('LOGGING_CONFIG')
-dictConfig(logging_config)
 
 # Get logger
-logger = logging.getLogger('delijn')
+logger = logging.getLogger("delijn")
 
 from .api import (
     get_formatted_arrivals,
@@ -29,48 +28,51 @@ from .api import (
     get_service_messages,
     get_nearest_stop,
     find_nearest_stops,
-    get_stop_by_name
+    get_stop_by_name,
 )
 
-provider_config = get_provider_config('delijn')
+provider_config = get_provider_config("delijn")
 logger.info("=== DE LIJN CONFIG DEBUG ===")
 logger.info(f"Raw config: {provider_config}")
 logger.info("=== END DE LIJN CONFIG DEBUG ===")
 
-GTFS_DIR = provider_config.get('GTFS_DIR')
-CACHE_DIR = provider_config.get('CACHE_DIR')
+GTFS_DIR = provider_config.get("GTFS_DIR")
+CACHE_DIR = provider_config.get("CACHE_DIR")
+
 
 class DelijnProvider(TransitProvider):
     """De Lijn transit provider"""
-    
+
     def __init__(self):
         # Initialize monitored lines and stops from config
         self.monitored_lines = []
         self.stop_ids = []
         self.cache_dir = Path(CACHE_DIR)
-        
-        config = get_provider_config('delijn')
-        self.stop_ids = config.get('STOP_IDS', [])
-        self.monitored_lines = config.get('MONITORED_LINES', [])
-        
+
+        config = get_provider_config("delijn")
+        self.stop_ids = config.get("STOP_IDS", [])
+        self.monitored_lines = config.get("MONITORED_LINES", [])
+
         # Define all endpoints
         endpoints = {
-            'config': self.get_config,
-            'data': self.get_data,
-            'stops': self.get_stop_details,
-            'route': get_line_shape,
-            'colors': get_line_color,
-            'vehicles': get_vehicle_positions,
-            'messages': get_service_messages,
-            'waiting_times': get_formatted_arrivals,
-            'nearest_stop': get_nearest_stop,
-            'get_stop_by_name': self.get_stop_by_name,
-            'get_nearest_stops': self.get_nearest_stops
+            "config": self.get_config,
+            "data": self.get_data,
+            "stops": self.get_stop_details,
+            "route": get_line_shape,
+            "colors": get_line_color,
+            "vehicles": get_vehicle_positions,
+            "messages": get_service_messages,
+            "waiting_times": get_formatted_arrivals,
+            "nearest_stop": get_nearest_stop,
+            "get_stop_by_name": self.get_stop_by_name,
+            "get_nearest_stops": self.get_nearest_stops,
         }
-        
+
         # Call parent class constructor
         super().__init__(name="De Lijn", endpoints=endpoints)
-        logger.info(f"De Lijn provider initialized with endpoints: {list(self.endpoints.keys())}")
+        logger.info(
+            f"De Lijn provider initialized with endpoints: {list(self.endpoints.keys())}"
+        )
 
     async def get_config(self):
         """Get De Lijn configuration including monitored stops and lines"""
@@ -79,19 +81,19 @@ class DelijnProvider(TransitProvider):
             stop_data = await get_formatted_arrivals([stop_id])
             stop_info = {
                 "id": stop_id,
-                "name": stop_data.get('stops', {}).get(stop_id, {}).get('name', 'Unknown Stop'),
-                "coordinates": stop_data.get('stops', {}).get(stop_id, {}).get('coordinates', {
-                    "lat": 50.85,
-                    "lon": 4.38
-                }),
-                "lines": {line: [] for line in self.monitored_lines}  # Empty list means all destinations
+                "name": stop_data.get("stops", {})
+                .get(stop_id, {})
+                .get("name", "Unknown Stop"),
+                "coordinates": stop_data.get("stops", {})
+                .get(stop_id, {})
+                .get("coordinates", {"lat": 50.85, "lon": 4.38}),
+                "lines": {
+                    line: [] for line in self.monitored_lines
+                },  # Empty list means all destinations
             }
             stops_config.append(stop_info)
 
-        return {
-            "stops": stops_config,
-            "monitored_lines": self.monitored_lines
-        }
+        return {"stops": stops_config, "monitored_lines": self.monitored_lines}
 
     async def get_data(self):
         """Get all real-time data for monitored De Lijn stops/lines"""
@@ -101,12 +103,10 @@ class DelijnProvider(TransitProvider):
                 "stops": {
                     stop_id: {
                         "name": "Unknown Stop",
-                        "coordinates": {
-                            "lat": 50.85,
-                            "lon": 4.38
-                        },
-                        "lines": {}
-                    } for stop_id in self.stop_ids
+                        "coordinates": {"lat": 50.85, "lon": 4.38},
+                        "lines": {},
+                    }
+                    for stop_id in self.stop_ids
                 }
             }
         return data
@@ -114,16 +114,13 @@ class DelijnProvider(TransitProvider):
     async def get_stop_details(self, stop_id: str):
         """Get details for a specific De Lijn stop"""
         arrivals = await get_formatted_arrivals([stop_id])
-        
+
         if not arrivals or stop_id not in arrivals.get("stops", {}):
             return {
                 "id": stop_id,
                 "name": "Unknown Stop",
-                "coordinates": {
-                    "lat": 50.85,
-                    "lon": 4.38
-                },
-                "lines": {}
+                "coordinates": {"lat": 50.85, "lon": 4.38},
+                "lines": {},
             }
 
         stop_data = arrivals["stops"][stop_id]
@@ -131,7 +128,7 @@ class DelijnProvider(TransitProvider):
             "id": stop_id,
             "name": stop_data["name"],
             "coordinates": stop_data["coordinates"],
-            "lines": {}
+            "lines": {},
         }
 
         # Extract unique lines and their destinations
@@ -140,16 +137,18 @@ class DelijnProvider(TransitProvider):
 
         return stop_details
 
-    async def get_nearest_stops(self, lat: float, lon: float, limit: int = 5, max_distance: float = 2.0):
+    async def get_nearest_stops(
+        self, lat: float, lon: float, limit: int = 5, max_distance: float = 2.0
+    ):
         """
         Get nearest De Lijn stops to the given coordinates.
-        
+
         Args:
             lat: Latitude
             lon: Longitude
             limit: Maximum number of stops to return
             max_distance: Maximum distance in kilometers to consider
-            
+
         Returns:
             List of dictionaries containing stop information and distance
         """
@@ -159,30 +158,32 @@ class DelijnProvider(TransitProvider):
         """Search for stops by name using the generic function."""
         try:
             # Get cached stops
-            stops = get_cached_stops(self.cache_dir / 'stops.json')
+            stops = get_cached_stops(self.cache_dir / "stops.json")
             if not stops:
                 logger.error("No stops data available")
                 return []
-                
+
             # Use the generic function
             matching_stops = generic_get_stop_by_name(stops, name, limit)
-            
+
             # Convert Stop objects to dictionaries
             return [asdict(stop) for stop in matching_stops] if matching_stops else []
-            
+
         except Exception as e:
             logger.error(f"Error in get_stop_by_name: {e}")
             return []
 
+
 # Only create and register provider if it's enabled
-if 'delijn' in get_config('ENABLED_PROVIDERS', []):
+if "delijn" in get_config("ENABLED_PROVIDERS", []):
     try:
         provider = DelijnProvider()
-        register_provider('delijn', provider)
+        register_provider("delijn", provider)
         logger.info("De Lijn provider registered successfully")
     except Exception as e:
         logger.error(f"Failed to register De Lijn provider: {e}")
         import traceback
+
         logger.error(f"Traceback: {traceback.format_exc()}")
 else:
     logger.warning("De Lijn provider is not enabled in configuration")

--- a/app/transit_providers/be/delijn/__init__.py
+++ b/app/transit_providers/be/delijn/__init__.py
@@ -8,13 +8,15 @@ from typing import Dict, Any, Callable, Awaitable, List
 from transit_providers.config import get_provider_config
 from config import get_config
 import logging
+from transit_providers import TransitProvider, register_provider, PROVIDERS
+from flask import request
+import asyncio
 from transit_providers.nearest_stop import (
     get_stop_by_name as generic_get_stop_by_name,
     get_cached_stops,
 )
 from dataclasses import asdict
 from pathlib import Path
-from transit_providers import TransitProvider, register_provider
 
 
 # Get logger
@@ -174,8 +176,8 @@ class DelijnProvider(TransitProvider):
             return []
 
 
-# Only create and register provider if it's enabled
-if "delijn" in get_config("ENABLED_PROVIDERS", []):
+# Only create and register provider if it's enabled and not already registered
+if "delijn" in get_config("ENABLED_PROVIDERS", []) and "delijn" not in PROVIDERS:
     try:
         provider = DelijnProvider()
         register_provider("delijn", provider)
@@ -184,6 +186,6 @@ if "delijn" in get_config("ENABLED_PROVIDERS", []):
         logger.error(f"Failed to register De Lijn provider: {e}")
         import traceback
 
-        logger.error(f"Traceback: {traceback.format_exc()}")
+        logger.error(traceback.format_exc())
 else:
     logger.warning("De Lijn provider is not enabled in configuration")

--- a/app/transit_providers/be/delijn/api.py
+++ b/app/transit_providers/be/delijn/api.py
@@ -11,10 +11,8 @@ import urllib.request
 import pytz
 import inspect
 import logging
-from logging.handlers import RotatingFileHandler
 import sys
 from config import get_config
-from logging.config import dictConfig
 import asyncio
 from transit_providers.config import get_provider_config
 import pytz
@@ -33,9 +31,6 @@ import csv
 from functools import lru_cache
 import hashlib
 
-# Setup logging using configuration
-logging_config = get_config("LOGGING_CONFIG")
-dictConfig(logging_config)
 
 # Get logger
 logger = logging.getLogger("delijn")

--- a/app/transit_providers/be/delijn/config.py
+++ b/app/transit_providers/be/delijn/config.py
@@ -3,33 +3,38 @@
 import os
 from pathlib import Path
 import logging
-from logging.config import dictConfig
 from transit_providers.config import get_config, register_provider_config
 
-# Setup logging using configuration
-logging_config = get_config('LOGGING_CONFIG')
-dictConfig(logging_config)
 # Get logger
-logger = logging.getLogger('delijn')
+logger = logging.getLogger("transit_providers.be.delijn")
 
 # Register default configuration
 DEFAULT_CONFIG = {
-    'STOP_IDS': ["307250", "307251"],  # Example stops - should be set in local.py
-    'MONITORED_LINES': ["116","117", '118', '144'],  # Example lines - should be set in local.py
-    'API_URL': 'https://api.delijn.be/DLKernOpenData/api/v1',
-    '_AVAILABLE_LANGUAGES': ['nl'],  # De Lijn only provides Dutch content
-    'GTFS_URL': 'https://api.delijn.be/gtfs/static/v3/gtfs_transit.zip',
-    'GTFS_DIR': Path('cache/delijn/gtfs'),
-    'CACHE_DIR': Path('cache/delijn'),
-    'RATE_LIMIT_DELAY': 0.5,  # seconds between API calls
-    'GTFS_CACHE_DURATION': 86400*30,  # 30 days in seconds
-    'API_KEY': os.getenv('DELIJN_API_KEY'),  # Main API key for real-time data
-    'GTFS_STATIC_API_KEY': os.getenv('DELIJN_GTFS_STATIC_API_KEY'),  # API key for static GTFS data
-    'GTFS_REALTIME_API_KEY': os.getenv('DELIJN_GTFS_REALTIME_API_KEY'),  # API key for GTFS-RT data
-    'GTFS_USED_FILES': ['stops.txt', 'routes.txt', 'trips.txt', 'shapes.txt']
+    "STOP_IDS": ["307250", "307251"],  # Example stops - should be set in local.py
+    "MONITORED_LINES": [
+        "116",
+        "117",
+        "118",
+        "144",
+    ],  # Example lines - should be set in local.py
+    "API_URL": "https://api.delijn.be/DLKernOpenData/api/v1",
+    "_AVAILABLE_LANGUAGES": ["nl"],  # De Lijn only provides Dutch content
+    "GTFS_URL": "https://api.delijn.be/gtfs/static/v3/gtfs_transit.zip",
+    "GTFS_DIR": Path("cache/delijn/gtfs"),
+    "CACHE_DIR": Path("cache/delijn"),
+    "RATE_LIMIT_DELAY": 0.5,  # seconds between API calls
+    "GTFS_CACHE_DURATION": 86400 * 30,  # 30 days in seconds
+    "API_KEY": os.getenv("DELIJN_API_KEY"),  # Main API key for real-time data
+    "GTFS_STATIC_API_KEY": os.getenv(
+        "DELIJN_GTFS_STATIC_API_KEY"
+    ),  # API key for static GTFS data
+    "GTFS_REALTIME_API_KEY": os.getenv(
+        "DELIJN_GTFS_REALTIME_API_KEY"
+    ),  # API key for GTFS-RT data
+    "GTFS_USED_FILES": ["stops.txt", "routes.txt", "trips.txt", "shapes.txt"],
 }
 
 logger.debug("Registering De Lijn default configuration")
 # Register this provider's default configuration
-register_provider_config('delijn', DEFAULT_CONFIG)
+register_provider_config("delijn", DEFAULT_CONFIG)
 logger.debug("De Lijn default configuration registered")

--- a/app/transit_providers/be/stib/api.py
+++ b/app/transit_providers/be/stib/api.py
@@ -5,7 +5,6 @@ from datetime import datetime, timezone, timedelta
 from typing import Dict, Any, List, Tuple, Optional, Union
 import pytz
 import logging
-from logging.config import dictConfig
 import asyncio
 from pathlib import Path
 from dataclasses import asdict
@@ -34,10 +33,6 @@ from .locate_vehicles import (
 )
 from .validate_stops import validate_line_stops, load_route_shape
 
-# Setup logging using configuration
-logging_config = get_config("LOGGING_CONFIG")
-dictConfig(logging_config)
-
 # Get logger
 logger = logging.getLogger("stib")
 
@@ -53,8 +48,8 @@ logger.debug(f"MESSAGES_API_URL: {MESSAGES_API_URL}")
 WAITING_TIMES_API_URL = provider_config.get("STIB_WAITING_TIME_API_URL", "")
 logger.debug(f"WAITING_TIMES_API_URL: {WAITING_TIMES_API_URL}")
 GTFS_URL = provider_config.get("GTFS_URL", "")
-GTFS_DIR = get_config('GTFS_DIR')
-CACHE_DIR = get_config('CACHE_DIR')
+GTFS_DIR = get_config("GTFS_DIR")
+CACHE_DIR = get_config("CACHE_DIR")
 SHAPES_CACHE_DIR = CACHE_DIR / "shapes"
 
 # Initialize caches

--- a/app/transit_providers/be/stib/config.py
+++ b/app/transit_providers/be/stib/config.py
@@ -3,46 +3,53 @@
 import os
 from pathlib import Path
 import logging
-from logging.config import dictConfig
 from transit_providers.config import get_config, register_provider_config
 from datetime import timedelta
-# Setup logging using configuration
-logging_config = get_config('LOGGING_CONFIG')
-dictConfig(logging_config)
+
 # Get logger
-logger = logging.getLogger('stib')
+logger = logging.getLogger("stib")
 
 # Register default configuration
 DEFAULT_CONFIG = {
-    'STIB_STOPS': [
-    {
-        'id': '5710',  # Example stop - VERBOECKHOVEN (different from global default)
-        'name': 'VERBOECKHOVEN',
-        'lines': {
-            '55': ['DA VINCI', 'ROGIER'],
-            '92': ['SCHAERBEEK GARE', 'FORT-JACO']
-        },
-        "direction": "City"  # or "Suburb"
-    } # Example stop, different from default.py to track config precedence
-], 
- "API_KEY": os.getenv('STIB_API_KEY'),
- "_AVAILABLE_LANGUAGES": ['en', 'fr', 'nl'],  # Languages available in STIB API responses
- 'API_URL': "https://data.stib-mivb.brussels/api/explore/v2.1/catalog/datasets",
+    "STIB_STOPS": [
+        {
+            "id": "5710",  # Example stop - VERBOECKHOVEN (different from global default)
+            "name": "VERBOECKHOVEN",
+            "lines": {
+                "55": ["DA VINCI", "ROGIER"],
+                "92": ["SCHAERBEEK GARE", "FORT-JACO"],
+            },
+            "direction": "City",  # or "Suburb"
+        }  # Example stop, different from default.py to track config precedence
+    ],
+    "API_KEY": os.getenv("STIB_API_KEY"),
+    "_AVAILABLE_LANGUAGES": [
+        "en",
+        "fr",
+        "nl",
+    ],  # Languages available in STIB API responses
+    "API_URL": "https://data.stib-mivb.brussels/api/explore/v2.1/catalog/datasets",
     "STIB_API_URL_BASE": "https://data.stib-mivb.brussels/api/explore/v2.1/catalog/datasets",
     "STIB_STOPS_API_URL": "https://data.stib-mivb.brussels/api/explore/v2.1/catalog/datasets/stop-details-production/records",
     "STIB_WAITING_TIME_API_URL": "https://data.stib-mivb.brussels/api/explore/v2.1/catalog/datasets/waiting-time-rt-production/records",
     "STIB_MESSAGES_API_URL": "https://data.stib-mivb.brussels/api/explore/v2.1/catalog/datasets/travellers-information-rt-production/records",
-    'GTFS_API_URL': "https://data.stib-mivb.brussels/api/explore/v2.1/catalog/datasets/gtfs-files-production/records",
-    'GTFS_DIR': Path('cache/stib/gtfs'),
-    'CACHE_DIR': Path('cache/stib'),
-    'STOPS_CACHE_FILE': Path('cache/stib/stops.json'),
-    'CACHE_DURATION': timedelta(days=30),
-    'RATE_LIMIT_DELAY': 0.5,  # seconds between API calls
-    'GTFS_CACHE_DURATION': 86400*30,  # 30 days in seconds
-    'GTFS_USED_FILES': ['stops.txt', 'routes.txt', 'trips.txt', 'shapes.txt', 'translations.txt']
+    "GTFS_API_URL": "https://data.stib-mivb.brussels/api/explore/v2.1/catalog/datasets/gtfs-files-production/records",
+    "GTFS_DIR": Path("cache/stib/gtfs"),
+    "CACHE_DIR": Path("cache/stib"),
+    "STOPS_CACHE_FILE": Path("cache/stib/stops.json"),
+    "CACHE_DURATION": timedelta(days=30),
+    "RATE_LIMIT_DELAY": 0.5,  # seconds between API calls
+    "GTFS_CACHE_DURATION": 86400 * 30,  # 30 days in seconds
+    "GTFS_USED_FILES": [
+        "stops.txt",
+        "routes.txt",
+        "trips.txt",
+        "shapes.txt",
+        "translations.txt",
+    ],
 }
 
 logger.debug("Registering STIB default configuration")
 # Register this provider's default configuration
-register_provider_config('stib', DEFAULT_CONFIG)
+register_provider_config("stib", DEFAULT_CONFIG)
 logger.debug("STIB default configuration registered")

--- a/app/transit_providers/be/stib/get_stop_names.py
+++ b/app/transit_providers/be/stib/get_stop_names.py
@@ -6,7 +6,6 @@ from pathlib import Path
 from datetime import timedelta, datetime
 import json
 import logging
-from logging.config import dictConfig
 from transit_providers.config import get_provider_config
 from config import get_config
 from utils import select_language
@@ -15,19 +14,20 @@ import csv
 from dataclasses import dataclass
 from typing import Dict, Optional, Tuple, List, Any
 from .stop_coordinates import (
-    StopCoordinates, get_coordinates_from_gtfs,
+    StopCoordinates,
+    get_coordinates_from_gtfs,
     get_cached_coordinates as get_cached_gtfs_coordinates,
-    cache_coordinates as cache_gtfs_coordinates
+    cache_coordinates as cache_gtfs_coordinates,
 )
 
 # Get configuration
-provider_config = get_provider_config('stib')
-STOPS_API_URL = provider_config.get('STIB_STOPS_API_URL')
-API_KEY = provider_config.get('API_KEY')
-CACHE_DIR = provider_config.get('CACHE_DIR')
+provider_config = get_provider_config("stib")
+STOPS_API_URL = provider_config.get("STIB_STOPS_API_URL")
+API_KEY = provider_config.get("API_KEY")
+CACHE_DIR = provider_config.get("CACHE_DIR")
 STOPS_CACHE_FILE = CACHE_DIR / "stops.json"
-CACHE_DURATION = provider_config.get('CACHE_DURATION')
-GTFS_DIR = provider_config.get('GTFS_DIR')
+CACHE_DURATION = provider_config.get("CACHE_DURATION")
+GTFS_DIR = provider_config.get("GTFS_DIR")
 
 # Failure tracking configuration
 MAX_FAILURES = 5  # Maximum number of failures before we stop retrying
@@ -35,111 +35,124 @@ FAILURE_TIMEOUT = timedelta(hours=1)  # How long to wait before retrying after a
 BATCH_SIZE = 10  # Number of stops to fetch in a single API call
 
 # Setup logging using configuration
-logging_config = get_config('LOGGING_CONFIG')
-dictConfig(logging_config)
-language_precedence = get_config('LANGUAGE_PRECEDENCE')
+language_precedence = get_config("LANGUAGE_PRECEDENCE")
 # Get logger
-logger = logging.getLogger('stib.get_stop_names')
+logger = logging.getLogger("stib.get_stop_names")
 
 # Add GTFS translation cache
 _translations_cache = None
 _stops_trans_id_cache = None
 
+
 @dataclass
 class StopInfo:
     """Complete stop information including names and coordinates."""
+
     names: Dict[str, str]  # Language code to name mapping
     coordinates: Optional[StopCoordinates]
     metadata: Dict[str, Any]
     failures: Optional[Dict[str, Any]] = None
 
+
 def load_stops_trans_ids():
     """Load stop_id to trans_id mapping from GTFS stops.txt"""
     global _stops_trans_id_cache
-    
+
     if _stops_trans_id_cache is not None:
         return _stops_trans_id_cache
-        
+
     _stops_trans_id_cache = {}
     try:
-        stops_file = GTFS_DIR / 'stops.txt'
+        stops_file = GTFS_DIR / "stops.txt"
         if not stops_file.exists():
             logger.warning("stops.txt not found, triggering GTFS download")
             ensure_gtfs_data()
-            
-        with open(stops_file, 'r', encoding='utf-8') as f:
+
+        with open(stops_file, "r", encoding="utf-8") as f:
             reader = csv.DictReader(f)
             for row in reader:
-                stop_id = row.get('stop_id')
-                trans_id = row.get('stop_name')  # In STIB GTFS, stop_name contains trans_id
+                stop_id = row.get("stop_id")
+                trans_id = row.get(
+                    "stop_name"
+                )  # In STIB GTFS, stop_name contains trans_id
                 if stop_id and trans_id:
                     _stops_trans_id_cache[stop_id] = trans_id
-                    
-        logger.debug(f"Loaded {len(_stops_trans_id_cache)} stop_id to trans_id mappings from GTFS")
+
+        logger.debug(
+            f"Loaded {len(_stops_trans_id_cache)} stop_id to trans_id mappings from GTFS"
+        )
     except Exception as e:
         logger.error(f"Error loading stops.txt: {e}", exc_info=True)
         _stops_trans_id_cache = {}
-    
+
     return _stops_trans_id_cache
+
 
 def load_translations(trans_id_to_return=None):
     """Load stop name translations from GTFS translations.txt"""
     global _translations_cache
-    
+
     # Return from cache if available
     if _translations_cache is not None:
         if not trans_id_to_return:
             return _translations_cache
         return _translations_cache.get(trans_id_to_return, {})
-    
+
     _translations_cache = {}
     try:
-        translations_file = GTFS_DIR / 'translations.txt'
+        translations_file = GTFS_DIR / "translations.txt"
         if not translations_file.exists():
             logger.warning("translations.txt not found, triggering GTFS download")
             ensure_gtfs_data()
-            
-        with open(translations_file, 'r', encoding='utf-8') as f:
+
+        with open(translations_file, "r", encoding="utf-8") as f:
             reader = csv.DictReader(f)
             for row in reader:
-                trans_id = row.get('trans_id')
-                translation = row.get('translation')
-                lang = row.get('lang')
-                
+                trans_id = row.get("trans_id")
+                translation = row.get("translation")
+                lang = row.get("lang")
+
                 if all([trans_id, translation, lang]):
                     if trans_id not in _translations_cache:
                         _translations_cache[trans_id] = {}
                     _translations_cache[trans_id][lang] = translation
                 else:
-                    logger.warning(f"Incomplete translation row: trans_id={trans_id}, lang={lang}")
-                    
+                    logger.warning(
+                        f"Incomplete translation row: trans_id={trans_id}, lang={lang}"
+                    )
+
         logger.debug(f"Loaded {len(_translations_cache)} translations from GTFS")
     except Exception as e:
         logger.error(f"Error loading translations.txt: {e}", exc_info=True)
         _translations_cache = {}
-    
+
     if not trans_id_to_return:
         return _translations_cache
     return _translations_cache.get(trans_id_to_return, {})
 
+
 def normalize_stop_id(stop_id: str) -> str:
     """Remove any suffix (letters) from a stop ID."""
-    return ''.join(c for c in stop_id if c.isdigit())
+    return "".join(c for c in stop_id if c.isdigit())
+
 
 def get_stop_id_variants(stop_id: str) -> List[str]:
     """Get all possible variants of a stop ID to try."""
     base_id = normalize_stop_id(stop_id)
-    
+
     # If the original ID has a suffix, try:
     # 1. Original ID (e.g., 5710F)
     # 2. Base ID (e.g., 5710)
     if base_id != stop_id:
         return [stop_id, base_id]
-    
+
     # If the original ID has no suffix, try:
     # 1. Original ID (e.g., 5710)
     # 2. ID with suffixes (e.g., 5710F, 5710G)
-    return [stop_id] + [f"{base_id}{suffix}" for suffix in ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H']]
+    return [stop_id] + [
+        f"{base_id}{suffix}" for suffix in ["A", "B", "C", "D", "E", "F", "G", "H"]
+    ]
+
 
 def get_stop_info_from_gtfs(stop_id: str) -> Optional[StopInfo]:
     """Get stop information from GTFS data."""
@@ -147,78 +160,82 @@ def get_stop_info_from_gtfs(stop_id: str) -> Optional[StopInfo]:
         # First try to get translations
         stops_trans_ids = load_stops_trans_ids()
         translations = load_translations()
-        
+
         # Try all stop ID variants
         for variant_id in get_stop_id_variants(stop_id):
             trans_id = stops_trans_ids.get(variant_id)
             if trans_id and trans_id in translations:
                 trans_data = translations[trans_id]
-                if 'fr' in trans_data and 'nl' in trans_data:
+                if "fr" in trans_data and "nl" in trans_data:
                     # Get coordinates from GTFS
                     coords = get_coordinates_from_gtfs(variant_id)
-                    
+
                     return StopInfo(
-                        names={
-                            'fr': trans_data['fr'],
-                            'nl': trans_data['nl']
-                        },
+                        names={"fr": trans_data["fr"], "nl": trans_data["nl"]},
                         coordinates=coords,
                         metadata={
-                            'source': 'gtfs',
-                            'trans_id': trans_id,
-                            'original_id': variant_id if variant_id != stop_id else None
-                        }
+                            "source": "gtfs",
+                            "trans_id": trans_id,
+                            "original_id": (
+                                variant_id if variant_id != stop_id else None
+                            ),
+                        },
                     )
-        
+
         return None
-            
+
     except Exception as e:
         logger.error(f"Error getting stop info from GTFS: {e}", exc_info=True)
         return None
 
+
 def should_retry_stop(stop_data):
     """Check if we should retry fetching a stop based on its failure history."""
-    failures = stop_data.get('_failures', {})
-    
+    failures = stop_data.get("_failures", {})
+
     # If no failure history or no coordinates, we should try
-    if not failures and not stop_data.get('coordinates', {}).get('lat'):
+    if not failures and not stop_data.get("coordinates", {}).get("lat"):
         return True
-    
-    fail_count = failures.get('count', 0)
-    last_failure = failures.get('last_failure')
-    
+
+    fail_count = failures.get("count", 0)
+    last_failure = failures.get("last_failure")
+
     # If we've failed too many times, don't retry
     if fail_count >= MAX_FAILURES:
         return False
-    
+
     # If we have a recent failure, don't retry yet
     if last_failure:
         last_failure_time = datetime.fromisoformat(last_failure)
         if datetime.now() - last_failure_time < FAILURE_TIMEOUT:
             return False
-    
+
     return True
+
 
 def load_cached_stops():
     """Load stop names from cache file"""
     if STOPS_CACHE_FILE.exists():
         try:
-            with open(STOPS_CACHE_FILE, 'r', encoding='utf-8') as f:
+            with open(STOPS_CACHE_FILE, "r", encoding="utf-8") as f:
                 return json.load(f)
         except Exception as e:
             logger.error(f"Error loading stops cache: {e}", exc_info=True)
     return {}
 
+
 # Load cached stops at startup
 cached_stops = load_cached_stops()
+
 
 def save_cached_stops(stops_data):
     """Save stop names to cache file"""
     try:
-        with open(STOPS_CACHE_FILE, 'w', encoding='utf-8') as f:
+        with open(STOPS_CACHE_FILE, "w", encoding="utf-8") as f:
             json.dump(stops_data, f, ensure_ascii=False, indent=2)
     except Exception as e:
         logger.error(f"Error saving stops cache: {e}", exc_info=True)
+
 
 def resolve_stop_name(stop_id, name_data=None):
     """Resolve stop name using multiple sources in order:
@@ -227,23 +244,16 @@ def resolve_stop_name(stop_id, name_data=None):
     3. GTFS stops.txt
     4. Stop ID as fallback
     """
-    result = {
-        'fr': None,
-        'nl': None,
-        '_metadata': {
-            'source': None,
-            'trans_id': None
-        }
-    }
+    result = {"fr": None, "nl": None, "_metadata": {"source": None, "trans_id": None}}
 
     # 1. Try API name data first
     if name_data:
-        result['fr'] = name_data.get('fr')
-        result['nl'] = name_data.get('nl')
-        result['_metadata']['source'] = 'api'
-        
+        result["fr"] = name_data.get("fr")
+        result["nl"] = name_data.get("nl")
+        result["_metadata"]["source"] = "api"
+
         # If we have both languages, we're done
-        if result['fr'] and result['nl']:
+        if result["fr"] and result["nl"]:
             return result
 
     # 2. Try GTFS translations
@@ -251,37 +261,44 @@ def resolve_stop_name(stop_id, name_data=None):
         # First get trans_id from stops.txt
         stops_trans_ids = load_stops_trans_ids()
         trans_id = stops_trans_ids.get(stop_id)
-        
+
         if trans_id:
             logger.debug(f"Found trans_id {trans_id} for stop {stop_id}")
             translations = load_translations(trans_id)
             if translations:
                 # Only update missing languages
-                if not result['fr'] and 'fr' in translations:
-                    result['fr'] = translations['fr']
-                    logger.debug(f"Using GTFS French translation for stop {stop_id}: {translations['fr']}")
-                if not result['nl'] and 'nl' in translations:
-                    result['nl'] = translations['nl']
-                    logger.debug(f"Using GTFS Dutch translation for stop {stop_id}: {translations['nl']}")
-                result['_metadata']['source'] = 'gtfs_translations'
-                result['_metadata']['trans_id'] = trans_id
+                if not result["fr"] and "fr" in translations:
+                    result["fr"] = translations["fr"]
+                    logger.debug(
+                        f"Using GTFS French translation for stop {stop_id}: {translations['fr']}"
+                    )
+                if not result["nl"] and "nl" in translations:
+                    result["nl"] = translations["nl"]
+                    logger.debug(
+                        f"Using GTFS Dutch translation for stop {stop_id}: {translations['nl']}"
+                    )
+                result["_metadata"]["source"] = "gtfs_translations"
+                result["_metadata"]["trans_id"] = trans_id
             else:
                 logger.debug(f"No translations found for trans_id {trans_id}")
         else:
             logger.debug(f"No trans_id found for stop {stop_id}")
-            
+
     except Exception as e:
-        logger.error(f"Error loading GTFS translations for stop {stop_id}: {e}", exc_info=True)
+        logger.error(
+            f"Error loading GTFS translations for stop {stop_id}: {e}", exc_info=True
+        )
 
     # 3. Use stop ID as fallback for any missing language
-    if not result['fr']:
-        result['fr'] = stop_id
+    if not result["fr"]:
+        result["fr"] = stop_id
         logger.debug(f"Using stop_id as fallback for French name: {stop_id}")
-    if not result['nl']:
-        result['nl'] = stop_id
+    if not result["nl"]:
+        result["nl"] = stop_id
         logger.debug(f"Using stop_id as fallback for Dutch name: {stop_id}")
 
     return result
+
 
 def get_stop_names(stop_ids, preferred_language=None):
     """Fetch stop names and coordinates for a list of stop IDs, using cache when possible"""
@@ -299,18 +316,22 @@ def get_stop_names(stop_ids, preferred_language=None):
             if gtfs_info:
                 logger.debug(f"Found complete GTFS info for stop {stop_id}")
                 cached_stops[stop_id] = {
-                    'name': gtfs_info.names['fr'],  # For v1 API backward compatibility
-                    'names': gtfs_info.names,
-                    'coordinates': {
-                        'lat': gtfs_info.coordinates.lat if gtfs_info.coordinates else None,
-                        'lon': gtfs_info.coordinates.lon if gtfs_info.coordinates else None
+                    "name": gtfs_info.names["fr"],  # For v1 API backward compatibility
+                    "names": gtfs_info.names,
+                    "coordinates": {
+                        "lat": (
+                            gtfs_info.coordinates.lat if gtfs_info.coordinates else None
+                        ),
+                        "lon": (
+                            gtfs_info.coordinates.lon if gtfs_info.coordinates else None
+                        ),
                     },
-                    '_metadata': gtfs_info.metadata,
-                    '_failures': {
-                        'count': 0,
-                        'last_failure': None,
-                        'normalized_id': None
-                    }
+                    "_metadata": gtfs_info.metadata,
+                    "_failures": {
+                        "count": 0,
+                        "last_failure": None,
+                        "normalized_id": None,
+                    },
                 }
 
     # Now filter stops that still need API data
@@ -321,65 +342,84 @@ def get_stop_names(stop_ids, preferred_language=None):
         # 1. Not in cache at all
         # 2. No coordinates and we should retry
         # 3. Has coordinates but they're None and we should retry
-        if (stop_id not in cached_stops or
-            (not stop_data.get('coordinates') and should_retry_stop(stop_data)) or
-            (stop_data.get('coordinates', {}).get('lat') is None and should_retry_stop(stop_data))):
+        if (
+            stop_id not in cached_stops
+            or (not stop_data.get("coordinates") and should_retry_stop(stop_data))
+            or (
+                stop_data.get("coordinates", {}).get("lat") is None
+                and should_retry_stop(stop_data)
+            )
+        ):
             stops_to_fetch.append(stop_id)
         else:
-            logger.debug(f"Skipping API fetch for stop {stop_id}: " + (
-                "max failures reached" if stop_data.get('_failures', {}).get('count', 0) >= MAX_FAILURES
-                else "recent failure" if stop_data.get('_failures', {}).get('last_failure')
-                else "already cached with coordinates" if stop_data.get('coordinates', {}).get('lat')
-                else "has GTFS info"
-            ))
+            logger.debug(
+                f"Skipping API fetch for stop {stop_id}: "
+                + (
+                    "max failures reached"
+                    if stop_data.get("_failures", {}).get("count", 0) >= MAX_FAILURES
+                    else (
+                        "recent failure"
+                        if stop_data.get("_failures", {}).get("last_failure")
+                        else (
+                            "already cached with coordinates"
+                            if stop_data.get("coordinates", {}).get("lat")
+                            else "has GTFS info"
+                        )
+                    )
+                )
+            )
 
     if stops_to_fetch:
         logger.info(f"Fetching {len(stops_to_fetch)} stops from API")
-        
+
         # Process stops in batches
         for i in range(0, len(stops_to_fetch), BATCH_SIZE):
-            batch = stops_to_fetch[i:i + BATCH_SIZE]
-            logger.debug(f"Processing batch {i//BATCH_SIZE + 1}/{(len(stops_to_fetch) + BATCH_SIZE - 1)//BATCH_SIZE}")
-            
+            batch = stops_to_fetch[i : i + BATCH_SIZE]
+            logger.debug(
+                f"Processing batch {i//BATCH_SIZE + 1}/{(len(stops_to_fetch) + BATCH_SIZE - 1)//BATCH_SIZE}"
+            )
+
             # Build OR query for all stops in batch
             variant_queries = []
             for stop_id in batch:
                 variants = get_stop_id_variants(stop_id)
                 variant_queries.extend([f'id="{v}"' for v in variants])
-            
-            query = ' OR '.join(variant_queries)
+
+            query = " OR ".join(variant_queries)
             params = {
-                'where': f'({query})',
-                'limit': len(variant_queries),  # Adjust limit to match number of variants
-                'apikey': API_KEY
+                "where": f"({query})",
+                "limit": len(
+                    variant_queries
+                ),  # Adjust limit to match number of variants
+                "apikey": API_KEY,
             }
 
             try:
                 response = requests.get(STOPS_API_URL, params=params)
                 logger.debug(f"Batch API Response status: {response.status_code}")
-                
+
                 if response.status_code != 200:
                     logger.warning(f"Batch API Response text: {response.text}")
                     # Mark all stops in batch as failed
                     for stop_id in batch:
-                        failures = cached_stops.get(stop_id, {}).get('_failures', {})
+                        failures = cached_stops.get(stop_id, {}).get("_failures", {})
                         if stop_id not in cached_stops:
                             cached_stops[stop_id] = {
-                                'name': stop_id,
-                                'names': {'fr': stop_id, 'nl': stop_id},
-                                'coordinates': {'lat': None, 'lon': None},
-                                '_metadata': {'source': 'fallback'},
-                                '_failures': {
-                                    'count': failures.get('count', 0) + 1,
-                                    'last_failure': datetime.now().isoformat(),
-                                    'normalized_id': get_stop_id_variants(stop_id)[-1]
-                                }
+                                "name": stop_id,
+                                "names": {"fr": stop_id, "nl": stop_id},
+                                "coordinates": {"lat": None, "lon": None},
+                                "_metadata": {"source": "fallback"},
+                                "_failures": {
+                                    "count": failures.get("count", 0) + 1,
+                                    "last_failure": datetime.now().isoformat(),
+                                    "normalized_id": get_stop_id_variants(stop_id)[-1],
+                                },
                             }
                         else:
-                            cached_stops[stop_id]['_failures'] = {
-                                'count': failures.get('count', 0) + 1,
-                                'last_failure': datetime.now().isoformat(),
-                                'normalized_id': get_stop_id_variants(stop_id)[-1]
+                            cached_stops[stop_id]["_failures"] = {
+                                "count": failures.get("count", 0) + 1,
+                                "last_failure": datetime.now().isoformat(),
+                                "normalized_id": get_stop_id_variants(stop_id)[-1],
                             }
                     continue
 
@@ -388,37 +428,52 @@ def get_stop_names(stop_ids, preferred_language=None):
 
                 # Process results
                 found_stops = set()
-                for result in data['results']:
+                for result in data["results"]:
                     stop_data = result
-                    stop_id = stop_data['id']
-                    
+                    stop_id = stop_data["id"]
+
                     # Find original stop ID that matches this result
                     original_stop_id = None
                     for batch_stop_id in batch:
                         if stop_id in get_stop_id_variants(batch_stop_id):
                             original_stop_id = batch_stop_id
                             break
-                    
+
                     if not original_stop_id:
-                        logger.warning(f"Could not map result stop {stop_id} back to original stop ID")
+                        logger.warning(
+                            f"Could not map result stop {stop_id} back to original stop ID"
+                        )
                         continue
 
                     found_stops.add(original_stop_id)
 
                     # Extract coordinates
-                    gps_coords = json.loads(stop_data.get('gpscoordinates', '{}'))
+                    gps_coords = json.loads(stop_data.get("gpscoordinates", "{}"))
                     coordinates = {
-                        'lat': float(gps_coords.get('latitude')) if gps_coords.get('latitude') else None,
-                        'lon': float(gps_coords.get('longitude')) if gps_coords.get('longitude') else None
+                        "lat": (
+                            float(gps_coords.get("latitude"))
+                            if gps_coords.get("latitude")
+                            else None
+                        ),
+                        "lon": (
+                            float(gps_coords.get("longitude"))
+                            if gps_coords.get("longitude")
+                            else None
+                        ),
                     }
 
                     # If we have coordinates, also cache them in the GTFS coordinates cache
-                    if coordinates['lat'] is not None and coordinates['lon'] is not None:
+                    if (
+                        coordinates["lat"] is not None
+                        and coordinates["lon"] is not None
+                    ):
                         gtfs_coords = StopCoordinates(
-                            lat=coordinates['lat'],
-                            lon=coordinates['lon'],
-                            source='api',
-                            original_id=stop_id if stop_id != original_stop_id else None
+                            lat=coordinates["lat"],
+                            lon=coordinates["lon"],
+                            source="api",
+                            original_id=(
+                                stop_id if stop_id != original_stop_id else None
+                            ),
                         )
                         gtfs_cache = get_cached_gtfs_coordinates()
                         gtfs_cache[original_stop_id] = gtfs_coords
@@ -426,79 +481,85 @@ def get_stop_names(stop_ids, preferred_language=None):
 
                     # If we already have GTFS names, just update coordinates
                     if original_stop_id in cached_stops:
-                        cached_stops[original_stop_id]['coordinates'] = coordinates
-                        cached_stops[original_stop_id]['_failures'] = {
-                            'count': 0,
-                            'last_failure': None,
-                            'normalized_id': stop_id
+                        cached_stops[original_stop_id]["coordinates"] = coordinates
+                        cached_stops[original_stop_id]["_failures"] = {
+                            "count": 0,
+                            "last_failure": None,
+                            "normalized_id": stop_id,
                         }
-                        logger.debug(f"Updated coordinates for stop {original_stop_id} from API")
+                        logger.debug(
+                            f"Updated coordinates for stop {original_stop_id} from API"
+                        )
                     else:
                         # No GTFS data, use API data
-                        name_data = json.loads(stop_data['name'])
+                        name_data = json.loads(stop_data["name"])
                         resolved_names = resolve_stop_name(original_stop_id, name_data)
                         cached_stops[original_stop_id] = {
-                            'name': resolved_names['fr'],
-                            'names': {
-                                'fr': resolved_names['fr'],
-                                'nl': resolved_names['nl']
+                            "name": resolved_names["fr"],
+                            "names": {
+                                "fr": resolved_names["fr"],
+                                "nl": resolved_names["nl"],
                             },
-                            'coordinates': coordinates,
-                            '_metadata': resolved_names['_metadata'],
-                            '_failures': {
-                                'count': 0,
-                                'last_failure': None,
-                                'normalized_id': stop_id
-                            }
+                            "coordinates": coordinates,
+                            "_metadata": resolved_names["_metadata"],
+                            "_failures": {
+                                "count": 0,
+                                "last_failure": None,
+                                "normalized_id": stop_id,
+                            },
                         }
-                        logger.debug(f"Added stop {original_stop_id} to cache with API data")
+                        logger.debug(
+                            f"Added stop {original_stop_id} to cache with API data"
+                        )
 
                 # Mark unfound stops as failed
                 for stop_id in batch:
                     if stop_id not in found_stops:
-                        failures = cached_stops.get(stop_id, {}).get('_failures', {})
+                        failures = cached_stops.get(stop_id, {}).get("_failures", {})
                         if stop_id not in cached_stops:
                             cached_stops[stop_id] = {
-                                'name': stop_id,
-                                'names': {'fr': stop_id, 'nl': stop_id},
-                                'coordinates': {'lat': None, 'lon': None},
-                                '_metadata': {'source': 'fallback'},
-                                '_failures': {
-                                    'count': failures.get('count', 0) + 1,
-                                    'last_failure': datetime.now().isoformat(),
-                                    'normalized_id': get_stop_id_variants(stop_id)[-1]
-                                }
+                                "name": stop_id,
+                                "names": {"fr": stop_id, "nl": stop_id},
+                                "coordinates": {"lat": None, "lon": None},
+                                "_metadata": {"source": "fallback"},
+                                "_failures": {
+                                    "count": failures.get("count", 0) + 1,
+                                    "last_failure": datetime.now().isoformat(),
+                                    "normalized_id": get_stop_id_variants(stop_id)[-1],
+                                },
                             }
                         else:
-                            cached_stops[stop_id]['_failures'] = {
-                                'count': failures.get('count', 0) + 1,
-                                'last_failure': datetime.now().isoformat(),
-                                'normalized_id': get_stop_id_variants(stop_id)[-1]
+                            cached_stops[stop_id]["_failures"] = {
+                                "count": failures.get("count", 0) + 1,
+                                "last_failure": datetime.now().isoformat(),
+                                "normalized_id": get_stop_id_variants(stop_id)[-1],
                             }
-                        logger.warning(f"No data found for stop {stop_id}, failure count: {cached_stops[stop_id]['_failures']['count']}")
+                        logger.warning(
+                            f"No data found for stop {stop_id}, failure count: {cached_stops[stop_id]['_failures']['count']}"
+                        )
 
             except Exception as e:
                 logger.error(f"Error fetching batch of stops: {e}", exc_info=True)
                 # Mark all stops in batch as failed
                 for stop_id in batch:
-                    failures = cached_stops.get(stop_id, {}).get('_failures', {})
+                    failures = cached_stops.get(stop_id, {}).get("_failures", {})
                     if stop_id not in cached_stops:
                         cached_stops[stop_id] = {
-                            'name': stop_id,
-                            'names': {'fr': stop_id, 'nl': stop_id},
-                            'coordinates': {'lat': None, 'lon': None},
-                            '_metadata': {'source': 'fallback'},
-                            '_failures': {
-                                'count': failures.get('count', 0) + 1,
-                                'last_failure': datetime.now().isoformat(),
-                                'normalized_id': get_stop_id_variants(stop_id)[-1]
-                            }
+                            "name": stop_id,
+                            "names": {"fr": stop_id, "nl": stop_id},
+                            "coordinates": {"lat": None, "lon": None},
+                            "_metadata": {"source": "fallback"},
+                            "_failures": {
+                                "count": failures.get("count", 0) + 1,
+                                "last_failure": datetime.now().isoformat(),
+                                "normalized_id": get_stop_id_variants(stop_id)[-1],
+                            },
                         }
                     else:
-                        cached_stops[stop_id]['_failures'] = {
-                            'count': failures.get('count', 0) + 1,
-                            'last_failure': datetime.now().isoformat(),
-                            'normalized_id': get_stop_id_variants(stop_id)[-1]
+                        cached_stops[stop_id]["_failures"] = {
+                            "count": failures.get("count", 0) + 1,
+                            "last_failure": datetime.now().isoformat(),
+                            "normalized_id": get_stop_id_variants(stop_id)[-1],
                         }
 
         # Save updated cache
@@ -508,29 +569,39 @@ def get_stop_names(stop_ids, preferred_language=None):
     # Return requested stop details from cache with language selection
     result = {}
     for stop_id in stop_ids:  # Use original stop_ids to maintain order
-        stop_data = cached_stops.get(stop_id, {
-            'name': stop_id,
-            'names': {'fr': stop_id, 'nl': stop_id},
-            'coordinates': {'lat': None, 'lon': None},
-            '_metadata': {'source': 'fallback'}
-        })
-        
+        stop_data = cached_stops.get(
+            stop_id,
+            {
+                "name": stop_id,
+                "names": {"fr": stop_id, "nl": stop_id},
+                "coordinates": {"lat": None, "lon": None},
+                "_metadata": {"source": "fallback"},
+            },
+        )
+
         # Ensure we have a names field
-        if 'names' not in stop_data:
-            stop_data['names'] = {'fr': stop_data.get('name', stop_id), 'nl': stop_data.get('name', stop_id)}
-        
-        # Apply language selection
-        name_with_metadata, _metadata = select_language(content=stop_data['names'], provider_languages=language_precedence, requested_language=preferred_language)
-        
-        result[stop_id] = {
-            'name': name_with_metadata,
-            'coordinates': stop_data['coordinates'],
-            '_metadata': {
-                'language': _metadata['language'],
-                'source': stop_data.get('_metadata', {}).get('source', 'fallback'),
-                'trans_id': stop_data.get('_metadata', {}).get('trans_id'),
-                'original_id': stop_data.get('_metadata', {}).get('original_id')
+        if "names" not in stop_data:
+            stop_data["names"] = {
+                "fr": stop_data.get("name", stop_id),
+                "nl": stop_data.get("name", stop_id),
             }
+
+        # Apply language selection
+        name_with_metadata, _metadata = select_language(
+            content=stop_data["names"],
+            provider_languages=language_precedence,
+            requested_language=preferred_language,
+        )
+
+        result[stop_id] = {
+            "name": name_with_metadata,
+            "coordinates": stop_data["coordinates"],
+            "_metadata": {
+                "language": _metadata["language"],
+                "source": stop_data.get("_metadata", {}).get("source", "fallback"),
+                "trans_id": stop_data.get("_metadata", {}).get("trans_id"),
+                "original_id": stop_data.get("_metadata", {}).get("original_id"),
+            },
         }
-    
+
     return result

--- a/app/transit_providers/be/stib/gtfs.py
+++ b/app/transit_providers/be/stib/gtfs.py
@@ -2,7 +2,6 @@
 
 from transit_providers.config import get_provider_config
 import requests
-from logging.config import dictConfig
 import logging
 
 # Get logger

--- a/app/transit_providers/be/stib/locate_vehicles.py
+++ b/app/transit_providers/be/stib/locate_vehicles.py
@@ -5,16 +5,17 @@ import logging
 import math
 from math import sqrt, sin, cos, radians, asin, degrees
 
-from app.transit_providers.be.stib.validate_stops import validate_line_stops, load_route_shape, RouteVariant, Terminus, Stop
-from app.config import get_config
-from logging.config import dictConfig
+from app.transit_providers.be.stib.validate_stops import (
+    validate_line_stops,
+    load_route_shape,
+    RouteVariant,
+    Terminus,
+    Stop,
+)
 
-# Setup logging using configuration
-logging_config = get_config('LOGGING_CONFIG')
-dictConfig(logging_config)
 
 # Get logger
-logger = logging.getLogger('stib.locate_vehicles')
+logger = logging.getLogger("stib.locate_vehicles")
 
 
 @dataclass
@@ -33,21 +34,23 @@ class VehiclePosition:
     def to_dict(self):
         """Convert the VehiclePosition object to a dictionary for JSON serialization"""
         return {
-            'line': self.line,
-            'direction': self.direction,
-            'current_segment': self.current_segment,
-            'distance_to_next': self.distance_to_next,
-            'segment_length': self.segment_length,
-            'is_valid': self.is_valid,
-            'interpolated_position': self.interpolated_position,
-            'bearing': self.bearing
+            "line": self.line,
+            "direction": self.direction,
+            "current_segment": self.current_segment,
+            "distance_to_next": self.distance_to_next,
+            "segment_length": self.segment_length,
+            "is_valid": self.is_valid,
+            "interpolated_position": self.interpolated_position,
+            "bearing": self.bearing,
         }
 
     def __json__(self):
         return self.to_dict()
 
 
-def haversine_distance(point1: Tuple[float, float], point2: Tuple[float, float]) -> float:
+def haversine_distance(
+    point1: Tuple[float, float], point2: Tuple[float, float]
+) -> float:
     """
     Calculate the distance between two points on Earth using the Haversine formula.
     Points are (lat, lon) tuples.
@@ -56,65 +59,71 @@ def haversine_distance(point1: Tuple[float, float], point2: Tuple[float, float])
     # Validate inputs
     if not all(isinstance(x, (int, float)) for x in point1 + point2):
         raise ValueError(f"Invalid coordinates: point1={point1}, point2={point2}")
-        
+
     lat1, lon1 = point1
     lat2, lon2 = point2
-    
+
     R = 6371000  # Earth's radius in meters
-    
+
     # Convert to radians
     lat1, lon1, lat2, lon2 = map(radians, [lat1, lon1, lat2, lon2])
-    
+
     # Haversine formula
     dlat = lat2 - lat1
     dlon = lon2 - lon1
-    a = sin(dlat/2)**2 + cos(lat1) * cos(lat2) * sin(dlon/2)**2
+    a = sin(dlat / 2) ** 2 + cos(lat1) * cos(lat2) * sin(dlon / 2) ** 2
     c = 2 * asin(sqrt(a))
-    
+
     return R * c
 
 
-def calculate_segment_distance(shape_coords: List[List[float]], 
-                             start_idx: int, 
-                             end_idx: int) -> float:
+def calculate_segment_distance(
+    shape_coords: List[List[float]], start_idx: int, end_idx: int
+) -> float:
     """
     Calculate the total distance along a shape between two points.
     """
     total_distance = 0
     for i in range(start_idx, end_idx):
-        point1 = (shape_coords[i][1], shape_coords[i][0])    # lat, lon
-        point2 = (shape_coords[i+1][1], shape_coords[i+1][0])  # lat, lon
+        point1 = (shape_coords[i][1], shape_coords[i][0])  # lat, lon
+        point2 = (shape_coords[i + 1][1], shape_coords[i + 1][0])  # lat, lon
         total_distance += haversine_distance(point1, point2)
     return total_distance
 
 
-def find_stop_in_shape(stop_coords: Tuple[float, float], 
-                      shape_coords: List[List[float]], 
-                      max_distance: float = 50) -> Optional[int]:
+def find_stop_in_shape(
+    stop_coords: Tuple[float, float],
+    shape_coords: List[List[float]],
+    max_distance: float = 50,
+) -> Optional[int]:
     """
     Find the closest point in the shape to a stop.
     Returns the index in shape_coords or None if no close match found.
     stop_coords is (lat, lon)
     shape_coords is list of [lon, lat] pairs
     """
-    min_distance = float('inf')
+    min_distance = float("inf")
     best_idx = None
-    
+
     # Validate stop coordinates
     if not stop_coords or len(stop_coords) != 2:
         logger.error(f"Invalid stop coordinates: {stop_coords}")
         return None
-        
+
     for i, coord in enumerate(shape_coords):
         try:
             # Validate shape coordinates
-            if not coord or len(coord) != 2 or not all(isinstance(x, (int, float)) for x in coord):
+            if (
+                not coord
+                or len(coord) != 2
+                or not all(isinstance(x, (int, float)) for x in coord)
+            ):
                 logger.error(f"Invalid shape coordinate at index {i}: {coord}")
                 continue
-                
+
             # Shape coordinates are [lon, lat], need to swap for comparison
             shape_point = (coord[1], coord[0])  # Convert to (lat, lon)
-            
+
             try:
                 dist = haversine_distance(stop_coords, shape_point)
                 if dist < min_distance:
@@ -123,36 +132,40 @@ def find_stop_in_shape(stop_coords: Tuple[float, float],
             except ValueError as e:
                 logger.error(f"Distance calculation failed at index {i}: {e}")
                 continue
-                
+
         except (IndexError, TypeError) as e:
             logger.error(f"Invalid coordinate at index {i}: {coord}")
             logger.error(f"Error: {str(e)}")
             continue
-    
+
     if min_distance <= max_distance:
         return best_idx
     return None
 
+
 def calculate_bearing(lat1: float, lon1: float, lat2: float, lon2: float) -> float:
     """Calculate the bearing between two points in degrees"""
     lat1, lon1, lat2, lon2 = map(radians, [lat1, lon1, lat2, lon2])
-    
+
     dlon = lon2 - lon1
     y = sin(dlon) * cos(lat2)
     x = cos(lat1) * sin(lat2) - sin(lat1) * cos(lat2) * cos(dlon)
     bearing = degrees(math.atan2(y, x))
-    
+
     # Convert to 0-360 range
     return (bearing + 360) % 360
 
-def validate_segment(from_stop: Stop, 
-                    to_stop: Stop, 
-                    line: str,
-                    direction: str,
-                    distance_to_next: float,
-                    route_variant: RouteVariant,
-                    raw_data: Dict,
-                    **kwargs) -> Optional[VehiclePosition]:
+
+def validate_segment(
+    from_stop: Stop,
+    to_stop: Stop,
+    line: str,
+    direction: str,
+    distance_to_next: float,
+    route_variant: RouteVariant,
+    raw_data: Dict,
+    **kwargs,
+) -> Optional[VehiclePosition]:
     """
     Validate a vehicle's position and calculate segment details.
     """
@@ -160,122 +173,144 @@ def validate_segment(from_stop: Stop,
         # Load shape coordinates for this specific direction
         shape_coords = load_route_shape(line, direction)
         if not shape_coords:
-            logger.error(f"No shape coordinates found for line {line} direction {direction}")
+            logger.error(
+                f"No shape coordinates found for line {line} direction {direction}"
+            )
             return None
 
         # Validate stop coordinates exist and have the expected structure
-        if (not from_stop.get('coordinates') or 
-            not isinstance(from_stop['coordinates'], dict) or
-            not to_stop.get('coordinates') or 
-            not isinstance(to_stop['coordinates'], dict)):
-            logger.error(f"Missing coordinates for stops: from={from_stop.get('id')}, to={to_stop.get('id')}")
+        if (
+            not from_stop.get("coordinates")
+            or not isinstance(from_stop["coordinates"], dict)
+            or not to_stop.get("coordinates")
+            or not isinstance(to_stop["coordinates"], dict)
+        ):
+            logger.error(
+                f"Missing coordinates for stops: from={from_stop.get('id')}, to={to_stop.get('id')}"
+            )
             return None
 
         # Validate lat/lon values exist
-        from_lat = from_stop['coordinates'].get('lat')
-        from_lon = from_stop['coordinates'].get('lon')
-        to_lat = to_stop['coordinates'].get('lat')
-        to_lon = to_stop['coordinates'].get('lon')
+        from_lat = from_stop["coordinates"].get("lat")
+        from_lon = from_stop["coordinates"].get("lon")
+        to_lat = to_stop["coordinates"].get("lat")
+        to_lon = to_stop["coordinates"].get("lon")
 
         if any(coord is None for coord in [from_lat, from_lon, to_lat, to_lon]):
-            logger.error(f"Line {line}: Missing lat/lon values for stops {from_stop['id']} -> {to_stop['id']}: from=({from_lat}, {from_lon}), to=({to_lat}, {to_lon})")
+            logger.error(
+                f"Line {line}: Missing lat/lon values for stops {from_stop['id']} -> {to_stop['id']}: from=({from_lat}, {from_lon}), to=({to_lat}, {to_lon})"
+            )
             return None
 
         # Create coordinate tuples only after validation
         from_coords = (from_lat, from_lon)
         to_coords = (to_lat, to_lon)
-        
+
         # Find stops in shape
         from_idx = find_stop_in_shape(from_coords, shape_coords)
         to_idx = find_stop_in_shape(to_coords, shape_coords)
-        
+
         if from_idx is None or to_idx is None:
-            logger.error(f"Could not locate stops in shape: {from_stop.get('id')} ({from_stop.get('name', 'Unknown')}) or {to_stop.get('id')} ({to_stop.get('name', 'Unknown')})")
+            logger.error(
+                f"Could not locate stops in shape: {from_stop.get('id')} ({from_stop.get('name', 'Unknown')}) or {to_stop.get('id')} ({to_stop.get('name', 'Unknown')})"
+            )
             return None
-        
+
         # Ensure correct order
         if from_idx > to_idx:
             from_idx, to_idx = to_idx, from_idx
-        
+
         # Calculate total segment distance
         segment_length = calculate_segment_distance(shape_coords, from_idx, to_idx)
-        
+
         # Extract shape segment
-        shape_segment = shape_coords[from_idx:to_idx + 1]
-        
+        shape_segment = shape_coords[from_idx : to_idx + 1]
+
         # Validate reported distance with 20% tolerance
         tolerance = 1.2  # Allow reported distance to be up to 20% longer
         is_valid = distance_to_next <= segment_length * tolerance
-        
+
         if not is_valid:
             logger.warning(
                 f"Reported distance ({distance_to_next:.0f}m) is significantly greater than "
                 f"segment length ({segment_length:.0f}m) between "
                 f"{from_stop.get('id')} ({from_stop.get('name', 'Unknown')}) and {to_stop.get('id')} ({to_stop.get('name', 'Unknown')})"
             )
-        
+
         # Create vehicle position object
         position = VehiclePosition(
             line=line,
             direction=direction,
-            current_segment=(from_stop['id'], to_stop['id']),
+            current_segment=(from_stop["id"], to_stop["id"]),
             distance_to_next=min(distance_to_next, segment_length),  # Cap the distance
             segment_length=segment_length,
             is_valid=is_valid,
             shape_segment=shape_segment,
-            raw_data=raw_data
+            raw_data=raw_data,
         )
-        
+
         # Calculate interpolated position and bearing
         interpolated = interpolate_position(position)
         if interpolated:
             position.interpolated_position = interpolated
             # Calculate bearing from interpolated position to next point in shape
-            next_point = shape_segment[1] if len(shape_segment) > 1 else shape_segment[0]
-            position.bearing = calculate_bearing(
-                interpolated[0], interpolated[1],  # lat, lon of interpolated position
-                next_point[1], next_point[0]      # lat, lon of next point (swapped from [lon, lat])
+            next_point = (
+                shape_segment[1] if len(shape_segment) > 1 else shape_segment[0]
             )
-        
+            position.bearing = calculate_bearing(
+                interpolated[0],
+                interpolated[1],  # lat, lon of interpolated position
+                next_point[1],
+                next_point[0],  # lat, lon of next point (swapped from [lon, lat])
+            )
+
         return position
-        
+
     except Exception as e:
         import traceback
+
         logger.error(f"Error validating segment: {str(e)}")
         logger.error(f"Full traceback:\n{traceback.format_exc()}")
         logger.error(f"Input data:")
-        logger.error(f"  From stop: {from_stop.get('id')} ({from_stop.get('name', 'Unknown')}) at {from_stop.get('coordinates')}")
-        logger.error(f"  To stop: {to_stop.get('id')} ({to_stop.get('name', 'Unknown')}) at {to_stop.get('coordinates')}")
+        logger.error(
+            f"  From stop: {from_stop.get('id')} ({from_stop.get('name', 'Unknown')}) at {from_stop.get('coordinates')}"
+        )
+        logger.error(
+            f"  To stop: {to_stop.get('id')} ({to_stop.get('name', 'Unknown')}) at {to_stop.get('coordinates')}"
+        )
         logger.error(f"  Distance to next: {distance_to_next}m")
         logger.error(f"  Line: {line}, Direction: {direction}")
         logger.error(f"  Shape coords length: {len(shape_coords)}")
-        logger.error(f"  Found indices: from_idx={from_idx if 'from_idx' in locals() else 'N/A'}, to_idx={to_idx if 'to_idx' in locals() else 'N/A'}")
+        logger.error(
+            f"  Found indices: from_idx={from_idx if 'from_idx' in locals() else 'N/A'}, to_idx={to_idx if 'to_idx' in locals() else 'N/A'}"
+        )
         logger.error(f"  Raw vehicle data: {raw_data}")
         return None
 
 
-def find_vehicle_segment(vehicle_data: Dict, 
-                        route_variant: RouteVariant,
-                        shape_coords: List[List[float]],
-                        line: str,
-                        direction: str) -> Optional[VehiclePosition]:
+def find_vehicle_segment(
+    vehicle_data: Dict,
+    route_variant: RouteVariant,
+    shape_coords: List[List[float]],
+    line: str,
+    direction: str,
+) -> Optional[VehiclePosition]:
     """
     Find which segment a vehicle is on and validate its position
     """
-    next_stop_id = vehicle_data['next_stop']
-    distance = vehicle_data['distance']
-    
+    next_stop_id = vehicle_data["next_stop"]
+    distance = vehicle_data["distance"]
+
     try:
         next_stop_index = next(
-            i for i, stop in enumerate(route_variant.stops)
-            if stop.id == next_stop_id
+            i for i, stop in enumerate(route_variant.stops) if stop.id == next_stop_id
         )
-        
+
         # The previous stop is where the vehicle is coming from
         if next_stop_index > 0:
             from_stop = route_variant.stops[next_stop_index - 1]
             to_stop = route_variant.stops[next_stop_index]
-            
+
             return validate_segment(
                 from_stop=from_stop,
                 to_stop=to_stop,
@@ -283,12 +318,14 @@ def find_vehicle_segment(vehicle_data: Dict,
                 direction=direction,
                 distance_to_next=distance,
                 route_variant=route_variant,
-                raw_data=vehicle_data
+                raw_data=vehicle_data,
             )
         else:
-            logger.warning(f"Vehicle reporting next stop {next_stop_id} which is first stop in route")
+            logger.warning(
+                f"Vehicle reporting next stop {next_stop_id} which is first stop in route"
+            )
             return None
-            
+
     except StopIteration:
         logger.error(f"Next stop {next_stop_id} not found in route stop list")
         return None
@@ -300,30 +337,30 @@ async def get_terminus_stops(line: str) -> Dict[str, Terminus]:
     """
     variants = await validate_line_stops(line)
     terminus_map = {}
-    
+
     # First, get the known terminus stops
     for variant in variants:
         if not variant.stops:
             continue
-            
+
         terminus = variant.stops[-1]
-        terminus_map[terminus['id']] = Terminus(
-            stop_id=terminus['id'],
-            stop_name=terminus['name'],
+        terminus_map[terminus["id"]] = Terminus(
+            stop_id=terminus["id"],
+            stop_name=terminus["name"],
             direction=variant.direction,
-            destination=variant.destination
+            destination=variant.destination,
         )
         logger.debug(f"\nLine {line} {variant.direction}:")
         logger.debug(f"  Terminus: {terminus['name']} (ID: {terminus['id']})")
         logger.debug(f"  Heading to: {variant.destination['fr']}")
-    
+
     return terminus_map
 
 
 async def process_vehicle_positions(positions_data):
     """Process vehicle positions data into VehiclePosition objects"""
     vehicle_positions = []
-    
+
     for line_id, directions in positions_data.items():
         # Get route variants for this line
         variants = await validate_line_stops(line_id)
@@ -331,84 +368,112 @@ async def process_vehicle_positions(positions_data):
         if not variants:
             logger.error(f"No route variants found for line {line_id}")
             continue
-            
+
         # Create a mapping of stop IDs to directions
         stop_to_direction = {}
         direction_to_stops = {}
         for variant in variants:
-            direction = variant.direction if hasattr(variant, 'direction') else variant['direction']
-            stops = variant.stops if hasattr(variant, 'stops') else variant['stops']
-            logger.debug(f"Processing variant with direction {direction} and {len(stops)} stops")
+            direction = (
+                variant.direction
+                if hasattr(variant, "direction")
+                else variant["direction"]
+            )
+            stops = variant.stops if hasattr(variant, "stops") else variant["stops"]
+            logger.debug(
+                f"Processing variant with direction {direction} and {len(stops)} stops"
+            )
             direction_to_stops[direction] = set()
             for stop in stops:
-                stop_id = stop['id'] if isinstance(stop, dict) else stop.id
+                stop_id = stop["id"] if isinstance(stop, dict) else stop.id
                 # Remove F/G suffixes for matching
-                stop_id = stop_id.rstrip('FG')
+                stop_id = stop_id.rstrip("FG")
                 stop_to_direction[stop_id] = direction
                 direction_to_stops[direction].add(stop_id)
-                
+
         logger.debug(f"Stop to direction mapping: {stop_to_direction}")
         logger.debug(f"Direction to stops mapping: {direction_to_stops}")
-                
+
         # Process each direction's vehicles
         for direction_id, vehicles_list in directions.items():
             # Find the route variant for this direction
             variant = next(
-                (v for v in variants 
-                 if (hasattr(v, 'direction') and v.direction == direction_id) or
-                    (isinstance(v, dict) and v['direction'] == direction_id)),
-                None
+                (
+                    v
+                    for v in variants
+                    if (hasattr(v, "direction") and v.direction == direction_id)
+                    or (isinstance(v, dict) and v["direction"] == direction_id)
+                ),
+                None,
             )
             if not variant:
-                logger.error(f"No route variant found for line {line_id} direction {direction_id}")
+                logger.error(
+                    f"No route variant found for line {line_id} direction {direction_id}"
+                )
                 continue
-                
+
             # Get stops list, handling both object and dict formats
-            stops = variant.stops if hasattr(variant, 'stops') else variant['stops']
-            
+            stops = variant.stops if hasattr(variant, "stops") else variant["stops"]
+
             # Process each vehicle
             for vehicle_data in vehicles_list:
                 try:
-                    next_stop = vehicle_data['next_stop'].rstrip('FG')
-                    
+                    next_stop = vehicle_data["next_stop"].rstrip("FG")
+
                     # Find the stop in the variant's stop list
                     stop_index = next(
-                        (i for i, stop in enumerate(stops)
-                         if (isinstance(stop, dict) and stop['id'].rstrip('FG') == next_stop) or
-                            (hasattr(stop, 'id') and stop.id.rstrip('FG') == next_stop)),
-                        None
+                        (
+                            i
+                            for i, stop in enumerate(stops)
+                            if (
+                                isinstance(stop, dict)
+                                and stop["id"].rstrip("FG") == next_stop
+                            )
+                            or (
+                                hasattr(stop, "id")
+                                and stop.id.rstrip("FG") == next_stop
+                            )
+                        ),
+                        None,
                     )
                     if stop_index is None:
-                        logger.error(f"Stop {next_stop} not found in variant for line {line_id}")
+                        logger.error(
+                            f"Stop {next_stop} not found in variant for line {line_id}"
+                        )
                         continue
-                        
+
                     # Get the next stop in the sequence
                     if stop_index + 1 < len(stops):
                         next_stop_obj = stops[stop_index + 1]
-                        next_stop_id = next_stop_obj['id'] if isinstance(next_stop_obj, dict) else next_stop_obj.id
+                        next_stop_id = (
+                            next_stop_obj["id"]
+                            if isinstance(next_stop_obj, dict)
+                            else next_stop_obj.id
+                        )
                         current_segment = [next_stop, next_stop_id]
-                        
+
                         # Create VehiclePosition object
                         position = VehiclePosition(
                             line=line_id,
                             direction=direction_id,
                             current_segment=current_segment,
-                            distance_to_next=vehicle_data['distance'],
+                            distance_to_next=vehicle_data["distance"],
                             segment_length=None,  # Will be calculated later if needed
                             is_valid=True,
                             interpolated_position=None,  # Will be calculated later
                             bearing=None,  # Will be calculated later
                             shape_segment=None,  # Will be calculated later
-                            raw_data=vehicle_data
+                            raw_data=vehicle_data,
                         )
                         vehicle_positions.append(position)
                     else:
-                        logger.warning(f"Vehicle at terminal stop {next_stop} on line {line_id}")
-                        
+                        logger.warning(
+                            f"Vehicle at terminal stop {next_stop} on line {line_id}"
+                        )
+
                 except Exception as e:
                     logger.error(f"Error processing vehicle on line {line_id}: {e}")
                     continue
-                    
+
     return vehicle_positions
 
 
@@ -419,34 +484,37 @@ def interpolate_position(vehicle: VehiclePosition) -> Optional[Tuple[float, floa
     """
     if not vehicle.is_valid or not vehicle.shape_segment:
         return None
-        
+
     # Distance from start of segment
     distance_from_start = vehicle.segment_length - vehicle.distance_to_next
-    
+
     # Walk along shape until we find our position
     current_distance = 0
     for i in range(len(vehicle.shape_segment) - 1):
-        point1 = (vehicle.shape_segment[i][1], vehicle.shape_segment[i][0])     # lat, lon
-        point2 = (vehicle.shape_segment[i+1][1], vehicle.shape_segment[i+1][0]) # lat, lon
-        
+        point1 = (vehicle.shape_segment[i][1], vehicle.shape_segment[i][0])  # lat, lon
+        point2 = (
+            vehicle.shape_segment[i + 1][1],
+            vehicle.shape_segment[i + 1][0],
+        )  # lat, lon
+
         segment_distance = haversine_distance(point1, point2)
         next_distance = current_distance + segment_distance
-        
+
         if next_distance >= distance_from_start:
             # Our position is on this mini-segment
             fraction = (distance_from_start - current_distance) / segment_distance
-            
+
             # Linear interpolation
             lat = point1[0] + fraction * (point2[0] - point1[0])
             lon = point1[1] + fraction * (point2[1] - point1[1])
-            
+
             # Calculate bearing
             vehicle.bearing = calculate_bearing(lat, lon, point2[0], point2[1])
-            
+
             return (lat, lon)
-            
+
         current_distance = next_distance
-    
+
     # If we get here, we're at the end of the segment
     last_point = vehicle.shape_segment[-1]
     return (last_point[1], last_point[0])  # Return last point instead of None
@@ -454,18 +522,56 @@ def interpolate_position(vehicle: VehiclePosition) -> Optional[Tuple[float, floa
 
 if __name__ == "__main__":
     # Example vehicle positions data
-    example_positions = {"56": {"2378": [{"distance": 32, "next_stop": "6190"}, {"distance": 70, "next_stop": "1062"}], "6465": [{"distance": 0, "next_stop": "3080"}, {"distance": 0, "next_stop": "6461"}, {"distance": 0, "next_stop": "2379"}, {"distance": 0, "next_stop": "2379"}]}, "59": {"3125": [{"distance": 358, "next_stop": "3099"}, {"distance": 40, "next_stop": "6465"}], "3130": [{"distance": 0, "next_stop": "3172"}, {"distance": 359, "next_stop": "3155"}, {"distance": 52, "next_stop": "9296"}, {"distance": 0, "next_stop": "3125"}]}, "64": {"3134": [{"distance": 75, "next_stop": "3185"}, {"distance": 6, "next_stop": "5299"}, {"distance": 258, "next_stop": "1729"}], "4952": [{"distance": 50, "next_stop": "1162"}, {"distance": 49, "next_stop": "2915"}]}}
-    
+    example_positions = {
+        "56": {
+            "2378": [
+                {"distance": 32, "next_stop": "6190"},
+                {"distance": 70, "next_stop": "1062"},
+            ],
+            "6465": [
+                {"distance": 0, "next_stop": "3080"},
+                {"distance": 0, "next_stop": "6461"},
+                {"distance": 0, "next_stop": "2379"},
+                {"distance": 0, "next_stop": "2379"},
+            ],
+        },
+        "59": {
+            "3125": [
+                {"distance": 358, "next_stop": "3099"},
+                {"distance": 40, "next_stop": "6465"},
+            ],
+            "3130": [
+                {"distance": 0, "next_stop": "3172"},
+                {"distance": 359, "next_stop": "3155"},
+                {"distance": 52, "next_stop": "9296"},
+                {"distance": 0, "next_stop": "3125"},
+            ],
+        },
+        "64": {
+            "3134": [
+                {"distance": 75, "next_stop": "3185"},
+                {"distance": 6, "next_stop": "5299"},
+                {"distance": 258, "next_stop": "1729"},
+            ],
+            "4952": [
+                {"distance": 50, "next_stop": "1162"},
+                {"distance": 49, "next_stop": "2915"},
+            ],
+        },
+    }
+
     vehicles = process_vehicle_positions(example_positions)
-    
+
     logger.info("\n=== Vehicle Positions ===")
     for vehicle in vehicles:
         logger.info(f"\nLine {vehicle.line} ({vehicle.direction})")
-        logger.info(f"  Between stops: {vehicle.current_segment[0]} → {vehicle.current_segment[1]}")
+        logger.info(
+            f"  Between stops: {vehicle.current_segment[0]} → {vehicle.current_segment[1]}"
+        )
         logger.info(f"  Distance to next stop: {vehicle.distance_to_next}m")
         logger.info(f"  Segment length: {vehicle.segment_length:.0f}m")
         logger.info(f"  Valid position: {vehicle.is_valid}")
-        
+
         if vehicle.is_valid:
             position = interpolate_position(vehicle)
             if position:

--- a/app/transit_providers/be/stib/routes.py
+++ b/app/transit_providers/be/stib/routes.py
@@ -9,23 +9,20 @@ from app.transit_providers.be.stib.get_stop_names import get_stop_names
 import logging
 from app.utils import RateLimiter, get_client
 from app.config import get_config
-from logging.config import dictConfig
 
 # Setup logging using configuration
-logging_config = get_config('LOGGING_CONFIG')
-dictConfig(logging_config)
 
 # Get logger
-logger = logging.getLogger('stib.routes')
+logger = logging.getLogger("stib.routes")
 
 # Create cache directories for shapefiles and stops
-SHAPES_CACHE_DIR = get_config('CACHE_DIR') / "shapes"
-STOPS_CACHE_DIR = get_config('CACHE_DIR') / "stops"
+SHAPES_CACHE_DIR = get_config("CACHE_DIR") / "shapes"
+STOPS_CACHE_DIR = get_config("CACHE_DIR") / "stops"
 
-CACHE_DURATION = get_config('CACHE_DURATION')
-API_KEY = get_config('STIB_API_KEY')
+CACHE_DURATION = get_config("CACHE_DURATION")
+API_KEY = get_config("STIB_API_KEY")
 
-RATE_LIMIT_DELAY = get_config('RATE_LIMIT_DELAY')
+RATE_LIMIT_DELAY = get_config("RATE_LIMIT_DELAY")
 
 # Keep track of last API call time
 last_api_call = datetime.min
@@ -35,339 +32,358 @@ rate_limiter = RateLimiter()
 
 # Variante 2: goint to city centre, variante 1: going to the suburbs
 
+
 def load_cached_shape(line: str) -> tuple[List[Dict], bool]:
     """Load shapefile from cache if it exists and is not expired"""
     cache_file = SHAPES_CACHE_DIR / f"line_{line}.json"
-    
+
     logger.debug(f"Checking cache for line {line} at {cache_file}")
-    
+
     if cache_file.exists():
         try:
-            with open(cache_file, 'r') as f:
+            with open(cache_file, "r") as f:
                 cache_data = json.load(f)
-            if cache_data:  
+            if cache_data:
                 # Check if cache is expired based on date_fin
                 current_date = datetime.now().date()
-                cache_expiry = datetime.strptime(cache_data['date_fin'], '%d/%m/%Y').date()
-                
+                cache_expiry = datetime.strptime(
+                    cache_data["date_fin"], "%d/%m/%Y"
+                ).date()
+
                 logger.debug(f"Cache found for line {line}:")
                 logger.debug(f"  Current date: {current_date}")
                 logger.debug(f"  Cache expiry: {cache_expiry}")
-                
+
                 if current_date > cache_expiry:
                     logger.debug(f"  Cache expired")
                     return [], True
-                        
+
                 logger.debug(f"  Cache valid")
-                return cache_data['variants'], False
+                return cache_data["variants"], False
             else:
                 logger.warning(f"Cache file for line {line} is empty")
                 return [], True
         except (json.JSONDecodeError, KeyError) as e:
             logger.error(f"Error reading cache for line {line}: {e}")
             return [], True
-    
+
     logger.debug(f"No cache file found for line {line}")
     return [], True
+
 
 def save_shape_to_cache(line: str, variants: List[Dict]) -> None:
     """Save shapefile data to cache"""
     cache_file = SHAPES_CACHE_DIR / f"line_{line}.json"
-    
+
     logger.info(f"Saving shape data to cache for line {line}")
     logger.debug(f"  Variants: {len(variants)}")
-    
+
     # Find the latest date_fin among all variants
-    latest_date_fin = max(v['date_fin'] for v in variants)
+    latest_date_fin = max(v["date_fin"] for v in variants)
     logger.debug(f"  Cache will expire on: {latest_date_fin}")
-    
+
     cache_data = {
-        'variants': variants,
-        'date_fin': latest_date_fin,
-        'cached_at': datetime.now().isoformat()
+        "variants": variants,
+        "date_fin": latest_date_fin,
+        "cached_at": datetime.now().isoformat(),
     }
-    
+
     try:
-        with open(cache_file, 'w') as f:
+        with open(cache_file, "w") as f:
             json.dump(cache_data, f)
         logger.debug(f"Successfully saved cache for line {line}")
     except Exception as e:
         import traceback
-        logger.error(f"Error saving cache for line {line}: {e}\n{traceback.format_exc()}")
+
+        logger.error(
+            f"Error saving cache for line {line}: {e}\n{traceback.format_exc()}"
+        )
+
 
 async def get_route_shape(line: str) -> List[Dict]:
     """Get route shape for a line, including all variants"""
     logger.debug(f"\n=== Starting shape fetch for line {line} ===")
-    
+
     cached_variants, should_refresh = load_cached_shape(line)
     if cached_variants and not should_refresh:
         return cached_variants
-        
+
     try:
         # Format line number to match API expectations
-        formatted_line = f"{int(line):03}b" # For bus lines
-        formatted_line_fallback = f"{int(line):03}t" # For tram lines
-        formatted_line_fallback_2 = f"{int(line):03}m" # For metro lines
+        formatted_line = f"{int(line):03}b"  # For bus lines
+        formatted_line_fallback = f"{int(line):03}t"  # For tram lines
+        formatted_line_fallback_2 = f"{int(line):03}m"  # For metro lines
         url = "https://stibmivb.opendatasoft.com/api/explore/v2.1/catalog/datasets/shapefiles-production/records"
         params = {
-            'where': f'ligne="{formatted_line}" or ligne="{formatted_line_fallback}" or ligne="{formatted_line_fallback_2}"',
-            'limit': 20,
-            'apikey': API_KEY
+            "where": f'ligne="{formatted_line}" or ligne="{formatted_line_fallback}" or ligne="{formatted_line_fallback_2}"',
+            "limit": 20,
+            "apikey": API_KEY,
         }
-        
+
         logger.debug(f"Making API request for line {line}")
-        
+
         async with await get_client() as client:
             response = await client.get(url, params=params)
             # Update rate limits from response headers
             rate_limiter.update_from_headers(response.headers)
-            
+
             logger.debug(f"API Response status: {response.status_code}")
-            
+
             if response.status_code != 200:
                 logger.error(f"Error response content: {response.text}")
             response.raise_for_status()
-            
+
             data = response.json()
             logger.debug(f"API returned {len(data.get('results', []))} results")
-            
+
             variants = []
-            for result in data['results']:
+            for result in data["results"]:
                 variant_data = {
-                    'variante': result['variante'],
-                    'date_debut': result['date_debut'],
-                    'date_fin': result['date_fin'],
-                    'coordinates': result['geo_shape']['geometry']['coordinates']
+                    "variante": result["variante"],
+                    "date_debut": result["date_debut"],
+                    "date_fin": result["date_fin"],
+                    "coordinates": result["geo_shape"]["geometry"]["coordinates"],
                 }
-                logger.debug(f"  Found variant {variant_data['variante']}: "
-                      f"{len(variant_data['coordinates'])} coordinates, "
-                      f"valid {variant_data['date_debut']} to {variant_data['date_fin']}")
+                logger.debug(
+                    f"  Found variant {variant_data['variante']}: "
+                    f"{len(variant_data['coordinates'])} coordinates, "
+                    f"valid {variant_data['date_debut']} to {variant_data['date_fin']}"
+                )
                 variants.append(variant_data)
-            
+
             if variants:
-                logger.debug(f"Successfully processed {len(variants)} variants for line {line}")
+                logger.debug(
+                    f"Successfully processed {len(variants)} variants for line {line}"
+                )
                 save_shape_to_cache(line, variants)
                 return variants
-                
+
             logger.warning(f"No shape data found for line {line}")
             logger.info(f"Full API Response: {response.text}")
             return cached_variants or []
 
     except httpx.HTTPStatusError as e:
         if e.response.status_code == 429:  # Too Many Requests
-            logger.warning(f"Rate limit hit for line {line}, using cached data if available")
-            if hasattr(e.response, 'headers'):
+            logger.warning(
+                f"Rate limit hit for line {line}, using cached data if available"
+            )
+            if hasattr(e.response, "headers"):
                 logger.info(f"Response headers: {e.response.headers}")
             return cached_variants
         else:
             logger.error(f"HTTP error fetching route shape for line {line}: {str(e)}")
-            logger.info(f"Response content: {e.response.text if hasattr(e, 'response') else 'No response content'}")
+            logger.info(
+                f"Response content: {e.response.text if hasattr(e, 'response') else 'No response content'}"
+            )
             return cached_variants or []
     except Exception as e:
         logger.error(f"Unexpected error fetching route shape for line {line}: {str(e)}")
         import traceback
+
         logger.error(f"Traceback: {traceback.format_exc()}")
         return cached_variants or []
     finally:
         logger.debug(f"=== Finished shape fetch for line {line} ===\n")
 
+
 def load_cached_stops(line: str) -> tuple[Dict, bool]:
     """Load stops from cache if it exists and is not expired"""
     cache_file = STOPS_CACHE_DIR / f"line_{line}_stops.json"
-    
+
     logger.debug(f"Checking stops cache for line {line} at {cache_file}")
-    
+
     if cache_file.exists():
         try:
-            with open(cache_file, 'r') as f:
+            with open(cache_file, "r") as f:
                 cache_data = json.load(f)
             if cache_data:
-                
-                cache_date = datetime.fromisoformat(cache_data['cached_at'])
+
+                cache_date = datetime.fromisoformat(cache_data["cached_at"])
                 if datetime.now() - cache_date < CACHE_DURATION:
                     logger.debug(f"Using cached stops data for line {line}")
-                    return cache_data['stops'], False
-                    
+                    return cache_data["stops"], False
+
                 logger.info(f"Stops cache expired for line {line}")
-                return cache_data['stops'], True
+                return cache_data["stops"], True
             else:
                 logger.warning(f"Stops cache file for line {line} is empty")
                 return {}, True
         except Exception as e:
             logger.error(f"Error reading stops cache for line {line}: {e}")
             return {}, True
-    
+
     logger.info(f"No stops cache found for line {line}")
     return {}, True
+
 
 def save_stops_to_cache(line: str, stops_data: Dict) -> None:
     """Save stops data to cache"""
     cache_file = STOPS_CACHE_DIR / f"line_{line}_stops.json"
-    
-    cache_data = {
-        'stops': stops_data,
-        'cached_at': datetime.now().isoformat()
-    }
-    
+
+    cache_data = {"stops": stops_data, "cached_at": datetime.now().isoformat()}
+
     try:
-        with open(cache_file, 'w') as f:
+        with open(cache_file, "w") as f:
             json.dump(cache_data, f)
         logger.debug(f"Saved stops cache for line {line}")
     except Exception as e:
         import traceback
-        logger.error(f"Error saving stops cache for line {line}: {e}\n{traceback.format_exc()}")
+
+        logger.error(
+            f"Error saving stops cache for line {line}: {e}\n{traceback.format_exc()}"
+        )
+
 
 async def get_stops_for_line(line: str) -> Dict[str, List[Dict]]:
     """Get ordered stops for both directions of a line"""
     cached_stops, should_refresh = load_cached_stops(line)
     if not should_refresh:
         return cached_stops
-        
+
     url = "https://stibmivb.opendatasoft.com/api/explore/v2.1/catalog/datasets/stops-by-line-production/records"
-    params = {
-        'where': f'lineid={line}',
-        'limit': 20,
-        'apikey': API_KEY
-    }
-    
+    params = {"where": f"lineid={line}", "limit": 20, "apikey": API_KEY}
+
     try:
         async with await get_client() as client:
             response = await client.get(url, params=params)
             # Update rate limits from response headers
             rate_limiter.update_from_headers(response.headers)
-            
+
             data = response.json()
-            
+
             stops_by_direction = {
-                'City': [],    # Will match with variant 2
-                'Suburb': []   # Will match with variant 1
+                "City": [],  # Will match with variant 2
+                "Suburb": [],  # Will match with variant 1
             }
-            
-            for route in data['results']:
-                direction = route['direction']
+
+            for route in data["results"]:
+                direction = route["direction"]
                 try:
-                    destination = json.loads(route['destination'])
-                    points = json.loads(route['points'])
+                    destination = json.loads(route["destination"])
+                    points = json.loads(route["points"])
                 except json.JSONDecodeError as e:
                     logger.error(f"Error parsing JSON for {direction} direction: {e}")
                     logger.info(f"Raw destination: {route['destination']}")
                     logger.info(f"Raw points: {route['points']}")
                     continue
-                
+
                 logger.debug(f"Processing direction: {direction}")
                 logger.debug(f"Destination: {destination['fr']} / {destination['nl']}")
                 logger.debug(f"Found {len(points)} stops")
-                
+
                 stops_by_direction[direction] = {
-                    'stops': points,
-                    'destination': destination
+                    "stops": points,
+                    "destination": destination,
                 }
-            
+
             # Save to cache if we got valid data
             if any(stops_by_direction.values()):
                 save_stops_to_cache(line, stops_by_direction)
-            
+
             return stops_by_direction
-            
+
     except httpx.HTTPStatusError as e:
         if e.response.status_code == 429:  # Too Many Requests
-            logger.warning(f"Rate limit hit for stops on line {line}, using cached data if available")
+            logger.warning(
+                f"Rate limit hit for stops on line {line}, using cached data if available"
+            )
             return cached_stops
         else:
             logger.error(f"HTTP error fetching stops for line {line}: {str(e)}")
-            logger.info(f"Response content: {e.response.text if hasattr(e, 'response') else 'No response content'}")
-            return cached_stops or {'City': [], 'Suburb': []}
+            logger.info(
+                f"Response content: {e.response.text if hasattr(e, 'response') else 'No response content'}"
+            )
+            return cached_stops or {"City": [], "Suburb": []}
     except Exception as e:
         logger.error(f"Unexpected error fetching stops for line {line}: {str(e)}")
         import traceback
+
         logger.error(f"Traceback: {traceback.format_exc()}")
-        return cached_stops or {'City': [], 'Suburb': []}
+        return cached_stops or {"City": [], "Suburb": []}
+
 
 def match_stops_to_variants(shapes: Dict, stops_by_direction: Dict) -> Dict:
     """Match stops to the correct shape variants"""
     result = {}
-    
+
     for line, variants in shapes.items():
         result[line] = []
         for variant in variants:
-            direction = 'City' if variant['variante'] == 2 else 'Suburb'
+            direction = "City" if variant["variante"] == 2 else "Suburb"
             variant_data = {
-                'variante': variant['variante'],
-                'coordinates': variant['coordinates'],
-                'date_fin': variant['date_fin'],
-                'direction': direction,
-                'stops': stops_by_direction.get(direction, {}).get('stops', []),
-                'destination': stops_by_direction.get(direction, {}).get('destination', {})
+                "variante": variant["variante"],
+                "coordinates": variant["coordinates"],
+                "date_fin": variant["date_fin"],
+                "direction": direction,
+                "stops": stops_by_direction.get(direction, {}).get("stops", []),
+                "destination": stops_by_direction.get(direction, {}).get(
+                    "destination", {}
+                ),
             }
             result[line].append(variant_data)
-    
+
     return result
+
 
 async def get_route_data(line: str) -> Dict[str, List[Dict]]:
     """Get route data for a line, including stops and destinations"""
     url = "https://stibmivb.opendatasoft.com/api/explore/v2.1/catalog/datasets/stops-by-line-production/records"
-    params = {
-        'where': f'lineid={line}',
-        'limit': 20,
-        'apikey': API_KEY
-    }
-    
+    params = {"where": f"lineid={line}", "limit": 20, "apikey": API_KEY}
+
     try:
         async with await get_client() as client:
             response = await client.get(url, params=params)
             # Update rate limits from response headers
             rate_limiter.update_from_headers(response.headers)
-            
+
             data = response.json()
             logger.debug(f"Got API response for line {line}: {data}")
-            
+
             variants = []
-            for route in data['results']:
+            for route in data["results"]:
                 try:
-                    destination = json.loads(route['destination'])
-                    points = json.loads(route['points'])
-                    direction = route['direction']
-                    
+                    destination = json.loads(route["destination"])
+                    points = json.loads(route["points"])
+                    direction = route["direction"]
+
                     logger.debug(f"Processing route variant:")
                     logger.debug(f"  Direction: {direction}")
                     logger.debug(f"  Destination: {destination}")
                     logger.debug(f"  Points: {points}")
-                    
+
                     # Create a list of stops with their order
                     stops = []
                     for point in points:
-                        stop_id = point['id']
-                        order = point['order']
-                        stops.append({
-                            'id': stop_id,
-                            'order': order
-                        })
-                    
+                        stop_id = point["id"]
+                        order = point["order"]
+                        stops.append({"id": stop_id, "order": order})
+
                     # Sort stops by order
-                    stops.sort(key=lambda x: x['order'])
-                    
+                    stops.sort(key=lambda x: x["order"])
+
                     # Create variant data
                     variant = {
-                        'direction': direction,
-                        'destination': destination,
-                        'stops': stops
+                        "direction": direction,
+                        "destination": destination,
+                        "stops": stops,
                     }
                     variants.append(variant)
                     logger.debug(f"Added variant with {len(stops)} stops")
-                    
+
                 except (json.JSONDecodeError, KeyError) as e:
                     logger.error(f"Error parsing route data for line {line}: {e}")
                     continue
-            
+
             if variants:
                 logger.debug(f"Returning {len(variants)} variants for line {line}")
                 return {line: variants}
             else:
                 logger.error(f"No valid route data found for line {line}")
                 return {}
-                
+
     except Exception as e:
         logger.error(f"Error getting route data for line {line}: {e}")
         import traceback
+
         logger.error(f"Traceback:\n{traceback.format_exc()}")
         return {}

--- a/app/transit_providers/be/stib/validate_stops.py
+++ b/app/transit_providers/be/stib/validate_stops.py
@@ -8,14 +8,10 @@ import os
 
 from app.config import get_config
 from app.transit_providers.be.stib.routes import get_route_data
-from logging.config import dictConfig
-
-# Setup logging using configuration
-logging_config = get_config('LOGGING_CONFIG')
-dictConfig(logging_config)
 
 # Get logger
-logger = logging.getLogger('stib.validate_stops')
+logger = logging.getLogger("stib.validate_stops")
+
 
 @dataclass
 class Stop:
@@ -23,6 +19,7 @@ class Stop:
     order: int
     name: str
     coordinates: Tuple[float, float]
+
 
 @dataclass
 class RouteVariant:
@@ -32,66 +29,81 @@ class RouteVariant:
     destination: Dict[str, str]  # {'fr': str, 'nl': str}
     shape: List[List[float]]
 
+
 @dataclass
 class Terminus:
     stop_id: str
     stop_name: str
     direction: str
     destination: Dict[str, str]
-    
+
     def get(self, key, default=None):
         """Add get method to make the class more dict-like"""
         return getattr(self, key, default)
 
+
 def load_stops_data() -> Dict[str, Dict]:
     """Load the master stops data with coordinates"""
     try:
-        with open('cache/stops.json', 'r') as f:
+        with open("cache/stops.json", "r") as f:
             return json.load(f)
     except FileNotFoundError:
         logger.warning(f"File cache/stops.json not found. Initializing empty cache.")
         # Create empty cache file
-        with open('cache/stops.json', 'w') as f:
+        with open("cache/stops.json", "w") as f:
             json.dump({}, f)
         return {}
 
+
 async def load_line_stops(line: str) -> Dict:
     """Load stops data for a line, fetching from API if needed"""
-    cache_path = f'cache/stops/line_{line}_stops.json'
-    
+    cache_path = f"cache/stops/line_{line}_stops.json"
+
     try:
-        with open(cache_path, 'r') as f:
+        with open(cache_path, "r") as f:
             if data := json.load(f):
-                return data['stops']
+                return data["stops"]
             else:
                 logger.warning(f"Cache file {cache_path} is empty")
                 return {}
     except FileNotFoundError:
         logger.info(f"No cache found for line {line}, fetching from API...")
         # Import here to avoid circular imports
-        try:   
+        try:
             from routes import get_route_data
         except ImportError:
             from app.routes import get_route_data
-        
+
         # Fetch the route data which includes stops
         route_data = await get_route_data(line)
         if route_data and line in route_data:
             # Extract stops data from route_data and save to cache
             stops_data = {
-                'City': next((variant for variant in route_data[line] 
-                            if variant['direction'] == 'City'), {}),
-                'Suburb': next((variant for variant in route_data[line] 
-                              if variant['direction'] == 'Suburb'), {})
+                "City": next(
+                    (
+                        variant
+                        for variant in route_data[line]
+                        if variant["direction"] == "City"
+                    ),
+                    {},
+                ),
+                "Suburb": next(
+                    (
+                        variant
+                        for variant in route_data[line]
+                        if variant["direction"] == "Suburb"
+                    ),
+                    {},
+                ),
             }
-            
+
             # Ensure cache directory exists
             os.makedirs(os.path.dirname(cache_path), exist_ok=True)
-            
+
             # Save to cache
-            with open(cache_path, 'w') as f:
-                json.dump({'stops': stops_data}, f)
-            
+            with open(cache_path, "w") as f:
+                json.dump({"stops": stops_data}, f)
+
             return stops_data
         else:
             logger.error(f"Failed to fetch route data for line {line}")
@@ -100,10 +112,12 @@ async def load_line_stops(line: str) -> Dict:
         logger.error(f"Error loading stops for line {line}: {e}")
         return {}
 
+
 async def validate_line_stops(line):
     try:
         # Get route data
         from routes import get_route_data  # Import the correct function
+
         route_data = await get_route_data(line)
         logger.debug(f"Got route data for line {line}: {route_data}")
         if not route_data or line not in route_data:
@@ -116,68 +130,76 @@ async def validate_line_stops(line):
 
         variants = []
         for variant in route_data[line]:
-            if 'stops' not in variant:
+            if "stops" not in variant:
                 logger.warning(f"No stops data found for line {line} variant")
                 continue
-                
+
             try:
-                stops = variant['stops']
-                direction = variant.get('direction', 'Unknown')
-                destination = variant.get('destination', {'fr': 'Unknown'})
-                
+                stops = variant["stops"]
+                direction = variant.get("direction", "Unknown")
+                destination = variant.get("destination", {"fr": "Unknown"})
+
                 logger.debug(f"Processing variant for line {line}:")
                 logger.debug(f"  Direction: {direction}")
                 logger.debug(f"  Destination: {destination}")
                 logger.debug(f"  Stops: {stops}")
-                
+
                 # Add coordinates to stops
                 for stop in stops:
-                    stop_id = stop['id']
+                    stop_id = stop["id"]
                     # Try with and without F/G suffix
-                    base_id = stop_id.rstrip('FG')
+                    base_id = stop_id.rstrip("FG")
                     if base_id in stops_data:
-                        stop['coordinates'] = stops_data[base_id]['coordinates']
-                        stop['name'] = stops_data[base_id].get('name', stop_id)  # Use stop ID as fallback name
+                        stop["coordinates"] = stops_data[base_id]["coordinates"]
+                        stop["name"] = stops_data[base_id].get(
+                            "name", stop_id
+                        )  # Use stop ID as fallback name
                     elif stop_id in stops_data:
-                        stop['coordinates'] = stops_data[stop_id]['coordinates']
-                        stop['name'] = stops_data[stop_id].get('name', stop_id)  # Use stop ID as fallback name
+                        stop["coordinates"] = stops_data[stop_id]["coordinates"]
+                        stop["name"] = stops_data[stop_id].get(
+                            "name", stop_id
+                        )  # Use stop ID as fallback name
                     else:
                         logger.warning(f"No coordinates found for stop {stop_id}")
-                        stop['coordinates'] = {'lat': None, 'lon': None}
-                        stop['name'] = stop_id  # Use stop ID as name if not found
-                
+                        stop["coordinates"] = {"lat": None, "lon": None}
+                        stop["name"] = stop_id  # Use stop ID as name if not found
+
                 # Get shape data for this variant
                 shape = load_route_shape(line, direction)
-                
+
                 # Create a variant for this direction
-                variants.append(RouteVariant(
-                    line=line,
-                    direction=direction,  # Use City/Suburb directly
-                    destination=destination,
-                    stops=stops,
-                    shape=shape
-                ))
+                variants.append(
+                    RouteVariant(
+                        line=line,
+                        direction=direction,  # Use City/Suburb directly
+                        destination=destination,
+                        stops=stops,
+                        shape=shape,
+                    )
+                )
                 logger.debug(f"Added variant for direction {direction}")
-                
+
             except Exception as e:
                 logger.error(f"Error processing variant for line {line}: {e}")
                 continue
-                
+
         logger.debug(f"Returning {len(variants)} variants for line {line}")
         return variants
-        
+
     except Exception as e:
         logger.error(f"Error validating stops for line {line}: {e}")
         return []
 
+
 def load_json_file(file_path: str) -> Dict:
     """Load a JSON file and return its contents as a dictionary"""
-    with open(file_path, 'r') as f:
+    with open(file_path, "r") as f:
         if data := json.load(f):
             return data
         else:
             logger.warning(f"Cache file {file_path} is empty")
             return {}
+
 
 def load_route_shape(line: str, direction: str = None) -> List[List[float]]:
     """
@@ -185,134 +207,156 @@ def load_route_shape(line: str, direction: str = None) -> List[List[float]]:
     Returns list of [lon, lat] coordinates for the specified direction.
     """
     try:
-        shape_file = f'cache/shapes/line_{line}.json'
+        shape_file = f"cache/shapes/line_{line}.json"
 
         if not Path(shape_file).exists():
             logger.error(f"Shape file {shape_file} not found")
             return []
-        
+
         shape_data = load_json_file(shape_file)
-        if not shape_data or 'variants' not in shape_data:
+        if not shape_data or "variants" not in shape_data:
             logger.error(f"No valid shape data found for line {line}")
             return []
 
         # Find the correct variant based on direction
-        variants = shape_data['variants']
+        variants = shape_data["variants"]
         variant = None
-        
+
         if direction:
             # Variant 1 is City, Variant 2 is Suburb
             variant = next(
-                (v for v in variants if 
-                 (v['variante'] == 1 and direction == 'City') or
-                 (v['variante'] == 2 and direction == 'Suburb')),
-                None
+                (
+                    v
+                    for v in variants
+                    if (v["variante"] == 1 and direction == "City")
+                    or (v["variante"] == 2 and direction == "Suburb")
+                ),
+                None,
             )
         else:
             # If no direction specified, use the first variant
             variant = variants[0] if variants else None
 
         if not variant:
-            logger.error(f"No matching variant found for line {line} direction {direction}")
+            logger.error(
+                f"No matching variant found for line {line} direction {direction}"
+            )
             return []
 
-        coordinates = variant.get('coordinates', [])
+        coordinates = variant.get("coordinates", [])
         if not coordinates:
             logger.error(f"No coordinates found in shape data for line {line}")
             return []
 
-        logger.debug(f"Loaded {len(coordinates)} coordinates for line {line} direction {direction}")
+        logger.debug(
+            f"Loaded {len(coordinates)} coordinates for line {line} direction {direction}"
+        )
         return coordinates
 
     except Exception as e:
         logger.error(f"Error loading shape for line {line}: {str(e)}")
         import traceback
+
         logger.error(f"Full traceback:\n{traceback.format_exc()}")
         return []
 
-def point_to_line_distance(point: Tuple[float, float], 
-                          line_start: Tuple[float, float], 
-                          line_end: Tuple[float, float]) -> float:
+
+def point_to_line_distance(
+    point: Tuple[float, float],
+    line_start: Tuple[float, float],
+    line_end: Tuple[float, float],
+) -> float:
     """Calculate the shortest distance from a point to a line segment"""
     # Convert to x,y coordinates (simplified, assuming small distances)
     px, py = point[1], point[0]  # lon, lat
     x1, y1 = line_start[1], line_start[0]
     x2, y2 = line_end[1], line_end[0]
-    
+
     # Calculate line segment length squared
-    line_length_sq = (x2 - x1)**2 + (y2 - y1)**2
-    
+    line_length_sq = (x2 - x1) ** 2 + (y2 - y1) ** 2
+
     if line_length_sq == 0:
         # Line segment is actually a point
-        return sqrt((px - x1)**2 + (py - y1)**2)
-    
+        return sqrt((px - x1) ** 2 + (py - y1) ** 2)
+
     # Calculate projection point parameter
     t = max(0, min(1, ((px - x1) * (x2 - x1) + (py - y1) * (y2 - y1)) / line_length_sq))
-    
+
     # Calculate closest point on line segment
     proj_x = x1 + t * (x2 - x1)
     proj_y = y1 + t * (y2 - y1)
-    
-    # Calculate distance
-    return sqrt((px - proj_x)**2 + (py - proj_y)**2)
 
-def validate_stops_on_route(variant: RouteVariant, shape_coords: List[List[float]], max_distance: float = 0.001) -> List[Dict]:
+    # Calculate distance
+    return sqrt((px - proj_x) ** 2 + (py - proj_y) ** 2)
+
+
+def validate_stops_on_route(
+    variant: RouteVariant, shape_coords: List[List[float]], max_distance: float = 0.001
+) -> List[Dict]:
     """
     Validate that stops are near the route line
     max_distance is in degrees (approximately 111m per 0.001 degrees at the equator)
     """
     issues = []
-    
+
     # For each stop
     for stop in variant.stops:
-        min_distance = float('inf')
+        min_distance = float("inf")
         stop_coords = (stop.coordinates[0], stop.coordinates[1])
-        
+
         # Check distance to each line segment
         for i in range(len(shape_coords) - 1):
             start_point = shape_coords[i]
             end_point = shape_coords[i + 1]
-            
+
             distance = point_to_line_distance(
                 stop_coords,
                 (start_point[1], start_point[0]),  # lat, lon
-                (end_point[1], end_point[0])
+                (end_point[1], end_point[0]),
             )
-            
+
             min_distance = min(min_distance, distance)
-        
+
         if min_distance > max_distance:
-            issues.append({
-                'stop_id': stop.id,
-                'stop_name': stop.name,
-                'distance': min_distance * 111000,  # Convert to approximate meters
-                'coordinates': stop_coords
-            })
-    
+            issues.append(
+                {
+                    "stop_id": stop.id,
+                    "stop_name": stop.name,
+                    "distance": min_distance * 111000,  # Convert to approximate meters
+                    "coordinates": stop_coords,
+                }
+            )
+
     return issues
+
 
 async def validate_line(line: str):
     """Validate all stops for a line against its route shapes"""
     variants = await validate_line_stops(line)
     shapes = load_route_shape(line)
-    
+
     for variant in variants:
         # Match variant with shape (variant 2 = City, variant 1 = Suburb)
         shape_variant = next(
-            (s for s in shapes if 
-             (s['variante'] == 2 and variant.direction == 'City') or
-             (s['variante'] == 1 and variant.direction == 'Suburb')),
-            None
+            (
+                s
+                for s in shapes
+                if (s["variante"] == 2 and variant.direction == "City")
+                or (s["variante"] == 1 and variant.direction == "Suburb")
+            ),
+            None,
         )
-        
+
         if not shape_variant:
             logger.error(f"No matching shape found for line {line} {variant.direction}")
             continue
-            
-        issues = validate_stops_on_route(variant, shape_variant['coordinates'])
-        
+
+        issues = validate_stops_on_route(variant, shape_variant["coordinates"])
+
         if issues:
-            logger.warning(f"\nLine {line} {variant.direction} has stops far from route:")
+            logger.warning(
+                f"\nLine {line} {variant.direction} has stops far from route:"
+            )
             for issue in issues:
                 logger.warning(
                     f"  {issue['stop_name']} (ID: {issue['stop_id']}) "
@@ -321,6 +365,7 @@ async def validate_line(line: str):
         else:
             logger.debug(f"\nLine {line} {variant.direction}: All stops are on route")
 
+
 def get_terminus_stops(line: str) -> Dict[str, Dict]:
     """
     Get terminus stop IDs for each direction of a line.
@@ -328,51 +373,54 @@ def get_terminus_stops(line: str) -> Dict[str, Dict]:
     """
     variants = validate_line_stops(line)
     terminus_map = {}
-    
+
     for variant in variants:
         if not variant.stops:
             logger.error(f"No stops found for line {line} {variant.direction}")
             continue
-            
+
         # Get both first and last stops of route
         first_stop = variant.stops[0]
         last_stop = variant.stops[-1]
-        
+
         # Add both terminus stops to the map with all necessary info as a dictionary
         terminus_map[first_stop.id] = {
-            'stop_id': first_stop.id,
-            'stop_name': first_stop.name,
-            'direction': variant.direction,
-            'destination': variant.destination
+            "stop_id": first_stop.id,
+            "stop_name": first_stop.name,
+            "direction": variant.direction,
+            "destination": variant.destination,
         }
-        
+
         terminus_map[last_stop.id] = {
-            'stop_id': last_stop.id,
-            'stop_name': last_stop.name,
-            'direction': variant.direction,
-            'destination': variant.destination
+            "stop_id": last_stop.id,
+            "stop_name": last_stop.name,
+            "direction": variant.direction,
+            "destination": variant.destination,
         }
-        
+
         logger.debug(f"\nLine {line} {variant.direction}:")
         logger.debug(f"  Start terminus: {first_stop.name} (ID: {first_stop.id})")
         logger.debug(f"  End terminus: {last_stop.name} (ID: {last_stop.id})")
-        logger.debug(f"  Heading to: {variant.destination['fr']} / {variant.destination['nl']}")
-    
+        logger.debug(
+            f"  Heading to: {variant.destination['fr']} / {variant.destination['nl']}"
+        )
+
     return terminus_map
+
 
 if __name__ == "__main__":
     # Test with lines 56 and 59
-    for line in ['56', '59', '64']:
+    for line in ["56", "59", "64"]:
         logger.info(f"\n=== Validating line {line} ===")
         validate_line(line)
-        
+
     # Test with all lines
     all_terminus = {}
-    for line in ['56', '59', '64']:
+    for line in ["56", "59", "64"]:
         logger.info(f"\n=== Analyzing terminus stops for line {line} ===")
         terminus_stops = get_terminus_stops(line)
         all_terminus[line] = terminus_stops
-        
+
     # Print summary
     logger.info("\n=== Terminus Summary ===")
     for line, terminus_data in all_terminus.items():

--- a/app/transit_providers/config.py
+++ b/app/transit_providers/config.py
@@ -2,39 +2,35 @@
 
 from typing import Dict, Any
 from config import get_config
-from logging.config import dictConfig
 import logging
 from copy import deepcopy
 from functools import lru_cache
 
-# Setup logging using configuration
-logging_config = get_config('LOGGING_CONFIG')
-dictConfig(logging_config)
-
 # Get logger
-logger = logging.getLogger('transit_providers.config')
+logger = logging.getLogger("transit_providers.config")
 
 # Registry for provider default configurations
 PROVIDER_DEFAULTS: Dict[str, Dict[str, Any]] = {}
 
+
 def deep_update(base_dict: Dict, update_dict: Dict) -> Dict:
     """Recursively update a dictionary, preserving nested structures.
-    
+
     When both uppercase and lowercase versions of a key exist:
     1. If updating with uppercase, only update uppercase
     2. If updating with lowercase, update both lowercase and uppercase
-    
+
     Lists and other non-dict values are always replaced entirely.
     Special cases:
     - When 'stops' is provided, 'STOP_IDS' is updated with the IDs from the stops list
     """
     result = deepcopy(base_dict)
-    
+
     # Special case: if 'stops' is provided, update STOP_IDS
-    if 'stops' in update_dict:
-        stop_ids = [stop['id'] for stop in update_dict['stops']]
-        result['STOP_IDS'] = stop_ids
-    
+    if "stops" in update_dict:
+        stop_ids = [stop["id"] for stop in update_dict["stops"]]
+        result["STOP_IDS"] = stop_ids
+
     for key, value in update_dict.items():
         # If the value is a dict and the existing value is also a dict, merge recursively
         if isinstance(value, dict) and key in result and isinstance(result[key], dict):
@@ -42,7 +38,7 @@ def deep_update(base_dict: Dict, update_dict: Dict) -> Dict:
         # For all other cases (including lists), replace entirely
         else:
             result[key] = deepcopy(value)
-            
+
         # If we're updating with a lowercase key and an uppercase version exists
         if not key.isupper() and key.upper() in result:
             upper_key = key.upper()
@@ -50,13 +46,17 @@ def deep_update(base_dict: Dict, update_dict: Dict) -> Dict:
                 result[upper_key] = deep_update(result[upper_key], value)
             else:
                 result[upper_key] = deepcopy(value)
-    
+
     return result
 
-def register_provider_config(provider_name: str, default_config: Dict[str, Any]) -> None:
+
+def register_provider_config(
+    provider_name: str, default_config: Dict[str, Any]
+) -> None:
     """Register a provider's default configuration"""
     PROVIDER_DEFAULTS[provider_name] = default_config
     logger.debug(f"Registered default config for {provider_name}")
+
 
 @lru_cache(maxsize=None)
 def get_provider_config(provider_name: str) -> Dict[str, Any]:
@@ -68,39 +68,49 @@ def get_provider_config(provider_name: str) -> Dict[str, Any]:
     # Start with provider-specific defaults (least important)
     config = deepcopy(PROVIDER_DEFAULTS.get(provider_name, {}))
     logger.debug(f"Starting with provider defaults for {provider_name}: {config}")
-    
+
     # Get all possible keys for this provider
     possible_keys = set(config.keys())  # Start with keys from provider defaults
-    possible_keys.update(get_config('PROVIDER_KEYS', {}).get(provider_name, []))  # Add keys from PROVIDER_KEYS
+    possible_keys.update(
+        get_config("PROVIDER_KEYS", {}).get(provider_name, [])
+    )  # Add keys from PROVIDER_KEYS
     logger.debug(f"Possible keys for {provider_name}: {possible_keys}")
-    
+
     # Merge values from default.py (overrides provider defaults)
     provider_upper = provider_name.upper()
-    
+
     # First, check for keys with provider prefix
     for key in possible_keys:
-        default_key = f"{provider_upper}_{key}" if not key.startswith(provider_upper) else key
+        default_key = (
+            f"{provider_upper}_{key}" if not key.startswith(provider_upper) else key
+        )
         default_value = get_config(default_key)
         logger.debug(f"Looking for default value for {default_key}: {default_value}")
         if default_value is not None:
-            if key in config and isinstance(config[key], dict) and isinstance(default_value, dict):
+            if (
+                key in config
+                and isinstance(config[key], dict)
+                and isinstance(default_value, dict)
+            ):
                 config[key] = deep_update(config[key], deepcopy(default_value))
             else:
                 config[key] = deepcopy(default_value)
-    
+
     # Then, check PROVIDER_CONFIG in default.py
-    default_provider_config = get_config('PROVIDER_CONFIG', {}).get(provider_name, {})
-    logger.debug(f"Provider config from default.py for {provider_name}: {default_provider_config}")
+    default_provider_config = get_config("PROVIDER_CONFIG", {}).get(provider_name, {})
+    logger.debug(
+        f"Provider config from default.py for {provider_name}: {default_provider_config}"
+    )
     if default_provider_config:
         config = deep_update(config, deepcopy(default_provider_config))
     logger.debug(f"After default.py for {provider_name}: {config}")
-    
+
     # Get user config from local.py and merge it (most important)
-    provider_config = get_config('PROVIDER_CONFIG', {})
+    provider_config = get_config("PROVIDER_CONFIG", {})
     user_config = deepcopy(provider_config.get(provider_name, {}))
     logger.debug(f"User config from local.py for {provider_name}: {user_config}")
     if user_config:
         config = deep_update(config, user_config)
     logger.debug(f"Final merged config for {provider_name}: {config}")
-    
+
     return config

--- a/app/transit_providers/hu/bkk/__init__.py
+++ b/app/transit_providers/hu/bkk/__init__.py
@@ -8,7 +8,8 @@ from typing import Dict, Any, Callable, Awaitable, List
 from transit_providers.config import get_provider_config
 from config import get_config
 import logging
-from transit_providers import TransitProvider, register_provider
+from transit_providers import TransitProvider, register_provider, PROVIDERS
+from flask import request
 import asyncio
 
 
@@ -75,8 +76,8 @@ class BKKProvider(TransitProvider):
         return await get_waiting_times(stop_id)
 
 
-# Only create and register provider if it's enabled
-if "bkk" in get_config("ENABLED_PROVIDERS", []):
+# Only create and register provider if it's enabled and not already registered
+if "bkk" in get_config("ENABLED_PROVIDERS", []) and "bkk" not in PROVIDERS:
     try:
         provider = BKKProvider()
         register_provider("bkk", provider)
@@ -85,9 +86,7 @@ if "bkk" in get_config("ENABLED_PROVIDERS", []):
         logger.error(f"Failed to register BKK provider: {e}")
         import traceback
 
-        logger.error(f"Traceback: {traceback.format_exc()}")
-else:
-    logger.warning("BKK provider is not enabled in configuration")
+        logger.error(traceback.format_exc())
 
 __all__ = [
     "bkk_config",

--- a/app/transit_providers/hu/bkk/__init__.py
+++ b/app/transit_providers/hu/bkk/__init__.py
@@ -8,13 +8,9 @@ from typing import Dict, Any, Callable, Awaitable, List
 from transit_providers.config import get_provider_config
 from config import get_config
 import logging
-from logging.config import dictConfig
 from transit_providers import TransitProvider, register_provider
 import asyncio
 
-# Setup logging using configuration
-logging_config = get_config("LOGGING_CONFIG")
-dictConfig(logging_config)
 
 # Get logger
 logger = logging.getLogger("bkk")

--- a/app/transit_providers/hu/bkk/api.py
+++ b/app/transit_providers/hu/bkk/api.py
@@ -4,7 +4,6 @@ import os
 from datetime import datetime, timezone, timedelta
 from zoneinfo import ZoneInfo
 import logging
-from logging.config import dictConfig
 from pathlib import Path
 import asyncio
 from typing import Dict, List, Optional, TypedDict, Any, Union, Tuple
@@ -45,38 +44,7 @@ __all__ = [
     "get_line_colors",
 ]
 
-# Setup logging
-logging_config = get_config("LOGGING_CONFIG")
-
-# Ensure log directory exists
-log_dir = Path(os.environ["PROJECT_ROOT"]) / "logs"
-# log_dir.mkdir(exist_ok=True)
-
-# Add handler for BKK provider if not exists
-if "handlers" not in logging_config:
-    logging_config["handlers"] = {}
-if "loggers" not in logging_config:
-    logging_config["loggers"] = {}
-
-logging_config["loggers"]["bkk"] = {
-    "handlers": ["legacy_app", "console"],
-    "level": "DEBUG",
-    "propagate": False,
-}
-
-logging_config["loggers"]["bkk.api"] = {
-    "handlers": ["legacy_app", "console"],
-    "level": "DEBUG",
-    "propagate": False,
-}
-
-logging_config["loggers"]["transit_providers.config"] = {
-    "handlers": ["legacy_app", "console"],
-    "level": "DEBUG",
-    "propagate": True,
-}
-
-dictConfig(logging_config)
+# Get logger
 logger = logging.getLogger("bkk")
 
 # Get provider configuration

--- a/app/transit_providers/test_bkk_performance.py
+++ b/app/transit_providers/test_bkk_performance.py
@@ -7,25 +7,25 @@ import asyncio
 import time
 from pathlib import Path
 import logging
-from logging.config import dictConfig
-from transit_providers.hu.bkk.api import get_waiting_times, _current_waiting_times_task, _last_waiting_times_result
-from transit_providers.config import get_provider_config
-from config import get_config
+from transit_providers.hu.bkk.api import (
+    get_waiting_times,
+    _current_waiting_times_task,
+    _last_waiting_times_result,
+)
 import httpx
 from google.transit import gtfs_realtime_pb2
 
-# Setup logging
-logging_config = get_config('LOGGING_CONFIG')
-dictConfig(logging_config)
-logger = logging.getLogger('performance')
+# Get logger
+logger = logging.getLogger("performance")
+
 
 async def test_waiting_times_performance(iterations: int = 10):
     """Test waiting times performance"""
     logger.info(f"Starting performance test with {iterations} iterations")
-    
+
     total_time = 0
     times = []
-    
+
     for i in range(iterations):
         start_time = time.time()
         try:
@@ -34,46 +34,49 @@ async def test_waiting_times_performance(iterations: int = 10):
             total_time += execution_time
             times.append(execution_time)
             logger.info(f"Iteration {i+1}: {execution_time:.2f} seconds")
-            
+
             # Log some statistics about the result
-            stops = len(result.get('stops_data', {}))
-            total_lines = sum(len(stop.get('lines', {})) 
-                            for stop in result.get('stops_data', {}).values())
+            stops = len(result.get("stops_data", {}))
+            total_lines = sum(
+                len(stop.get("lines", {}))
+                for stop in result.get("stops_data", {}).values()
+            )
             logger.info(f"Result contains {stops} stops and {total_lines} lines")
-            
+
         except Exception as e:
             logger.error(f"Error in iteration {i+1}: {e}")
-    
+
     # Calculate statistics
     avg_time = total_time / iterations
     min_time = min(times)
     max_time = max(times)
-    
+
     logger.info("Performance test results:")
     logger.info(f"Average execution time: {avg_time:.2f} seconds")
     logger.info(f"Minimum execution time: {min_time:.2f} seconds")
     logger.info(f"Maximum execution time: {max_time:.2f} seconds")
     logger.info(f"Total time for {iterations} iterations: {total_time:.2f} seconds")
 
+
 async def test_timeout_handling():
     """Test that requests timeout after 29 seconds"""
     logger.info("Starting timeout test")
-    
+
     # Save original client for restoration
     original_client = httpx.AsyncClient
-    
+
     try:
         # Create a mock client that's very slow
         class SlowClient:
             def __init__(self, *args, **kwargs):
                 pass
-                
+
             async def __aenter__(self):
                 return self
-                
+
             async def __aexit__(self, exc_type, exc_val, exc_tb):
                 pass
-                
+
             async def get(self, *args, **kwargs):
                 logger.info("Starting slow API call (35s)")
                 try:
@@ -94,20 +97,20 @@ async def test_timeout_handling():
         class MockResponse:
             def __init__(self):
                 self.content = None
-                
+
             def raise_for_status(self):
                 pass
-        
+
         # Monkey patch the client
         httpx.AsyncClient = SlowClient
-        
+
         # Clear any cached results
         global _last_waiting_times_result, _current_waiting_times_task
         _last_waiting_times_result = None
         if _current_waiting_times_task and not _current_waiting_times_task.done():
             _current_waiting_times_task.cancel()
         _current_waiting_times_task = None
-        
+
         start_time = time.time()
         try:
             result = await get_waiting_times()
@@ -116,45 +119,50 @@ async def test_timeout_handling():
             logger.info(f"Result: {result}")
             assert execution_time < 30, "Request took longer than 30 seconds"
             # Check that we get stop data with empty lines
-            assert 'stops_data' in result, "Response should contain stops_data"
-            for stop_id, stop_data in result['stops_data'].items():
-                assert 'name' in stop_data, f"Stop {stop_id} should have a name"
-                assert 'coordinates' in stop_data, f"Stop {stop_id} should have coordinates"
-                assert 'lines' in stop_data, f"Stop {stop_id} should have a lines key"
-                assert stop_data['lines'] == {}, f"Stop {stop_id} should have empty lines on timeout"
+            assert "stops_data" in result, "Response should contain stops_data"
+            for stop_id, stop_data in result["stops_data"].items():
+                assert "name" in stop_data, f"Stop {stop_id} should have a name"
+                assert (
+                    "coordinates" in stop_data
+                ), f"Stop {stop_id} should have coordinates"
+                assert "lines" in stop_data, f"Stop {stop_id} should have a lines key"
+                assert (
+                    stop_data["lines"] == {}
+                ), f"Stop {stop_id} should have empty lines on timeout"
             logger.info("Timeout test passed successfully")
         except Exception as e:
             logger.error(f"Error in timeout test: {e}")
             raise
-            
+
     finally:
         # Restore original client
         httpx.AsyncClient = original_client
 
+
 async def test_request_coalescing():
     """Test that multiple concurrent requests share the same result"""
     logger.info("Starting request coalescing test")
-    
+
     # Save original client for restoration
     original_client = httpx.AsyncClient
-    
+
     try:
         # Create a mock client that's moderately slow
         class ModeratelySlowClient:
             def __init__(self, *args, **kwargs):
                 pass
-                
+
             async def __aenter__(self):
                 return self
-                
+
             async def __aexit__(self, exc_type, exc_val, exc_tb):
                 pass
-                
+
             async def get(self, *args, **kwargs):
                 logger.info("Starting moderate API call (5s)")
                 await asyncio.sleep(5)  # Simulate a 5-second API call
                 logger.info("Moderate API call completed")
-                
+
                 # Create a mock response with minimal valid protobuf
                 class MockResponse:
                     def __init__(self):
@@ -164,52 +172,59 @@ async def test_request_coalescing():
                         feed.header.incrementality = 0  # FULL_DATASET
                         feed.header.timestamp = int(time.time())
                         self.content = feed.SerializeToString()
-                        
+
                     def raise_for_status(self):
                         pass
-                
+
                 return MockResponse()
-        
+
         # Monkey patch the client
         httpx.AsyncClient = ModeratelySlowClient
-        
+
         # Clear any cached results
         await clear_caches()
-        
+
         # Make multiple concurrent requests
         async def make_request(request_id: int, delay: float = 0):
             if delay:
-                await asyncio.sleep(delay)  # Add a small delay to ensure requests overlap
+                await asyncio.sleep(
+                    delay
+                )  # Add a small delay to ensure requests overlap
             start_time = time.time()
             result = await get_waiting_times()
             execution_time = time.time() - start_time
-            logger.info(f"Request {request_id} completed in {execution_time:.2f} seconds")
+            logger.info(
+                f"Request {request_id} completed in {execution_time:.2f} seconds"
+            )
             return result, execution_time
-        
+
         # Launch 3 concurrent requests with small delays to ensure they overlap
         tasks = [
             make_request(0),  # First request starts immediately
             make_request(1, delay=0.1),  # Second request starts after 0.1s
-            make_request(2, delay=0.2)  # Third request starts after 0.2s
+            make_request(2, delay=0.2),  # Third request starts after 0.2s
         ]
         results = await asyncio.gather(*tasks)
-        
+
         # Verify that all requests got the same result
         first_result = results[0][0]
         first_time = results[0][1]
-        
+
         # First request should take ~5s
         assert first_time >= 4.5, "First request was too fast"
-        
+
         for i, (result, execution_time) in enumerate(results[1:], 1):
             assert result == first_result, f"Request {i} got different result"
             # Subsequent requests should be faster as they share the result
-            assert execution_time < first_time, f"Request {i} was not faster than first request"
+            assert (
+                execution_time < first_time
+            ), f"Request {i} was not faster than first request"
             logger.info(f"Request {i} execution time: {execution_time:.2f}s")
-            
+
     finally:
         # Restore original client
         httpx.AsyncClient = original_client
+
 
 async def clear_caches():
     """Clear all caches between tests"""
@@ -217,49 +232,55 @@ async def clear_caches():
     from transit_providers.hu.bkk.api import (
         _last_waiting_times_result as api_last_result,
         _current_waiting_times_task as api_current_task,
-        _stops_cache, _routes_cache, _stops_cache_update, _routes_cache_update,
-        _stop_times_cache, _last_cache_update
+        _stops_cache,
+        _routes_cache,
+        _stops_cache_update,
+        _routes_cache_update,
+        _stop_times_cache,
+        _last_cache_update,
     )
-    
+
     # Clear waiting times cache in both modules
     _last_waiting_times_result = None
     if _current_waiting_times_task and not _current_waiting_times_task.done():
         _current_waiting_times_task.cancel()
     _current_waiting_times_task = None
-    
+
     # Clear API module caches
     api_last_result = None
     if api_current_task and not api_current_task.done():
         api_current_task.cancel()
     api_current_task = None
-    
+
     # Clear stop and route caches
     _stops_cache.clear()
     _routes_cache.clear()
     _stops_cache_update = None
     _routes_cache_update = None
-    
+
     # Clear stop times cache
     _stop_times_cache.clear()
     _last_cache_update = None
 
+
 async def run_all_tests():
     """Run all tests"""
     logger.info("=== Starting all tests ===")
-    
+
     logger.info("1. Testing timeout handling...")
     await clear_caches()
     await test_timeout_handling()
-    
+
     logger.info("\n2. Testing request coalescing...")
     await clear_caches()
     await test_request_coalescing()
-    
+
     logger.info("\n3. Testing performance...")
     await clear_caches()
     await test_waiting_times_performance(iterations=3)
-    
+
     logger.info("\n=== All tests completed ===")
 
+
 if __name__ == "__main__":
-    asyncio.run(run_all_tests()) 
+    asyncio.run(run_all_tests())

--- a/app/utils.py
+++ b/app/utils.py
@@ -2,16 +2,10 @@ import httpx
 from datetime import datetime, timedelta
 import logging
 from config import get_config
-from logging.config import dictConfig
-
-# Only configure logging if we're not being imported for testing
-if __name__ != "__main__" and not any(p.endswith('test_language_utils.py') for p in __import__('sys').argv):
-    # Setup logging using configuration
-    logging_config = get_config('LOGGING_CONFIG')
-    dictConfig(logging_config)
 
 # Get logger
-logger = logging.getLogger('utils')
+logger = logging.getLogger("utils")
+
 
 class RateLimiter:
     def __init__(self):
@@ -20,20 +14,20 @@ class RateLimiter:
         self.limit = None
         self.last_logged_hundreds = None
         self.first_update = True
-        
+
     def update_from_headers(self, headers):
         try:
             previous_remaining = self.remaining
-            self.remaining = int(headers.get('x-ratelimit-remaining', 0))
-            reset_time_str = headers.get('x-ratelimit-reset', '0')
+            self.remaining = int(headers.get("x-ratelimit-remaining", 0))
+            reset_time_str = headers.get("x-ratelimit-reset", "0")
             try:
                 self.reset_time = datetime.fromisoformat(reset_time_str)
             except (ValueError, TypeError):
                 # Fallback to current time plus 1 hour if parsing fails
                 self.reset_time = datetime.now() + timedelta(hours=1)
-            
-            self.limit = int(headers.get('x-ratelimit-limit', 0))
-            
+
+            self.limit = int(headers.get("x-ratelimit-limit", 0))
+
             # Log initial quota status
             if self.first_update:
                 logger.info(
@@ -41,56 +35,62 @@ class RateLimiter:
                     f"(Reset at {self.reset_time.strftime('%H:%M:%S')})"
                 )
                 self.first_update = False
-            
+
             # Log when we cross each hundred threshold
             elif previous_remaining is not None:
                 current_hundreds = self.remaining // 100
                 previous_hundreds = previous_remaining // 100
-                
+
                 if current_hundreds < previous_hundreds:
                     logger.info(
                         f"API calls remaining: {self.remaining}/{self.limit} "
                         f"(Reset at {self.reset_time.strftime('%H:%M:%S')})"
                     )
-            
+
             logger.debug(f"Rate limit update: {self.remaining} requests remaining")
             logger.debug(f"Reset time: {self.reset_time}")
-            
+
         except (ValueError, TypeError) as e:
             logger.warning(f"Error parsing rate limit headers: {e}")
             self.remaining = 0  # Set to 0 on error
             self.limit = 0
-            self.reset_time = datetime.now() + timedelta(hours=1)  # Set default reset time
+            self.reset_time = datetime.now() + timedelta(
+                hours=1
+            )  # Set default reset time
 
     def can_make_request(self) -> bool:
         """Check if we can make a request based on rate limits"""
         if self.remaining is None or self.reset_time is None:
             return True
-        
+
         if self.remaining <= 0:
             # Check if reset time has passed
             if datetime.now() > self.reset_time:
                 self.remaining = None
                 self.reset_time = None
                 return True
-                
-            logger.info(f"Rate limit exceeded. Reset at {self.reset_time.strftime('%H:%M:%S')}")
+
+            logger.info(
+                f"Rate limit exceeded. Reset at {self.reset_time.strftime('%H:%M:%S')}"
+            )
             return False
-            
+
         # Keep some requests in reserve
         return self.remaining > 100
 
+
 async def get_client():
-    return httpx.AsyncClient(timeout=30.0) 
+    return httpx.AsyncClient(timeout=30.0)
+
 
 def select_language(content, provider_languages, requested_language=None):
     """Select the best matching language for multilingual content.
-    
+
     Args:
         content: Content object that might contain language-specific versions
         provider_languages: List of languages available from the provider
         requested_language: Optional specific language to try first
-        
+
     Returns:
         tuple: (selected_content, metadata)
         metadata format:
@@ -104,7 +104,7 @@ def select_language(content, provider_languages, requested_language=None):
         }
     """
     from config import get_config
-    
+
     # If content is not a dictionary, return as is
     if not isinstance(content, dict):
         return content, {
@@ -112,18 +112,19 @@ def select_language(content, provider_languages, requested_language=None):
                 "requested": requested_language,
                 "provided": None,
                 "available": [],
-                "warning": None
+                "warning": None,
             }
         }
-    
+
     # Get language precedence from config
-    language_precedence = get_config('LANGUAGE_PRECEDENCE', ['en', 'fr', 'nl'])
-    
+    language_precedence = get_config("LANGUAGE_PRECEDENCE", ["en", "fr", "nl"])
+
     # Check if any keys look like language codes (2-3 chars)
     # Use list to preserve order from API
-    possible_lang_keys = [k for k in content.keys() 
-                         if isinstance(k, str) and len(k) in (2, 3)]
-    
+    possible_lang_keys = [
+        k for k in content.keys() if isinstance(k, str) and len(k) in (2, 3)
+    ]
+
     # If no keys look like language codes, return as is
     if not possible_lang_keys:
         return content, {
@@ -131,15 +132,16 @@ def select_language(content, provider_languages, requested_language=None):
                 "requested": requested_language,
                 "provided": None,
                 "available": [],
-                "warning": None
+                "warning": None,
             }
         }
-    
+
     # Get available languages that match our provider's languages
     # Use list comprehension to preserve order from API
-    available_languages = [lang for lang in possible_lang_keys 
-                         if lang in provider_languages]
-    
+    available_languages = [
+        lang for lang in possible_lang_keys if lang in provider_languages
+    ]
+
     # If we found language-like keys but none match our provider's languages,
     # this might indicate an API change
     if possible_lang_keys and not available_languages:
@@ -148,10 +150,10 @@ def select_language(content, provider_languages, requested_language=None):
                 "requested": requested_language,
                 "provided": None,
                 "available": possible_lang_keys,
-                "warning": f"Found unexpected language keys: {possible_lang_keys}. Possible API change?"
+                "warning": f"Found unexpected language keys: {possible_lang_keys}. Possible API change?",
             }
         }
-    
+
     # Build the fallback chain
     fallback_chain = []
     if requested_language and requested_language in provider_languages:
@@ -159,12 +161,12 @@ def select_language(content, provider_languages, requested_language=None):
     for lang in language_precedence:
         if lang in provider_languages and lang not in fallback_chain:
             fallback_chain.append(lang)
-    
+
     # Add any remaining provider languages in API order
     for lang in available_languages:
         if lang not in fallback_chain:
             fallback_chain.append(lang)
-    
+
     # Try each language in the chain
     for lang in fallback_chain:
         if lang in content and content[lang]:
@@ -173,39 +175,41 @@ def select_language(content, provider_languages, requested_language=None):
                     "requested": requested_language,
                     "provided": lang,
                     "available": available_languages,
-                    "warning": (f"Fallback to {lang}: content not available in {requested_language}"
-                              if requested_language and lang != requested_language
-                              else None)
+                    "warning": (
+                        f"Fallback to {lang}: content not available in {requested_language}"
+                        if requested_language and lang != requested_language
+                        else None
+                    ),
                 }
             }
-    
+
     # If we get here, we found language keys but couldn't get valid content
     return content, {
         "language": {
             "requested": requested_language,
             "provided": None,
             "available": available_languages,
-            "warning": "Found language keys but no valid content in any language"
+            "warning": "Found language keys but no valid content in any language",
         }
     }
+
 
 def matches_destination(configured_name: str, destination_data: dict) -> bool:
     """
     Check if a configured destination name matches any language version of the actual destination.
-    
+
     Args:
         configured_name: The destination name from config (e.g., "STOCKEL")
         destination_data: Multilingual destination data (e.g., {"fr": "STOCKEL", "nl": "STOKKEL"})
-        
+
     Returns:
         bool: True if the configured name matches any language version
     """
     if not destination_data or not isinstance(destination_data, dict):
         return False
-        
+
     # Normalize names for comparison (uppercase)
     configured_name = configured_name.upper()
     destination_values = [str(v).upper() for v in destination_data.values()]
-    
-    return configured_name in destination_values
 
+    return configured_name in destination_values

--- a/app/validate_stops.py
+++ b/app/validate_stops.py
@@ -6,15 +6,10 @@ import logging
 import os
 import sys
 from math import sqrt
-from config import get_config
-from logging.config import dictConfig
 
-# Setup logging using configuration
-logging_config = get_config('LOGGING_CONFIG')
-dictConfig(logging_config)
 
 # Get logger
-logger = logging.getLogger('validate_stops')
+logger = logging.getLogger("validate_stops")
 
 # Add the parent directory to the Python path
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
@@ -24,12 +19,14 @@ try:
 except ImportError:
     from routes import get_route_data
 
+
 @dataclass
 class Stop:
     id: str
     order: int
     name: str
     coordinates: Tuple[float, float]
+
 
 @dataclass
 class RouteVariant:
@@ -38,69 +35,84 @@ class RouteVariant:
     stops: List[Stop]
     destination: Dict[str, str]  # {'fr': str, 'nl': str}
 
+
 @dataclass
 class Terminus:
     stop_id: str
     stop_name: str
     direction: str
     destination: Dict[str, str]
-    
+
     def get(self, key, default=None):
         """Add get method to make the class more dict-like"""
         return getattr(self, key, default)
 
+
 def load_stops_data() -> Dict[str, Dict]:
     """Load the master stops data with coordinates"""
-    try:    
-        with open('cache/stops.json', 'r') as f:
+    try:
+        with open("cache/stops.json", "r") as f:
             return json.load(f)
     except FileNotFoundError:
         logger.warning("Stops data file not found, creating empty cache")
         # Create empty cache file
-        with open('cache/stops.json', 'w', encoding='utf-8') as f:
+        with open("cache/stops.json", "w", encoding="utf-8") as f:
             json.dump({}, f)
         logger.info("Created empty stops data file")
         return {}
 
+
 async def load_line_stops(line: str) -> Dict:
     """Load stops data for a line, fetching from API if needed"""
-    cache_path = f'cache/stops/line_{line}_stops.json'
-    
+    cache_path = f"cache/stops/line_{line}_stops.json"
+
     try:
-        with open(cache_path, 'r') as f:
-            return json.load(f)['stops']
+        with open(cache_path, "r") as f:
+            return json.load(f)["stops"]
     except FileNotFoundError:
         logger.info(f"No cache found for line {line}, fetching from API...")
 
         logger.info(f"Also, initializing routes cache...")
-        with open(cache_path, 'w') as f:
+        with open(cache_path, "w") as f:
             json.dump({}, f)
         logger.info("Created empty routes cache file")
-        
+
         # Import here to avoid circular imports
-        try:   
+        try:
             from routes import get_route_data
         except ImportError:
             from app.routes import get_route_data
-        
+
         # Fetch the route data which includes stops
         route_data = await get_route_data(line)
         if route_data and line in route_data:
             # Extract stops data from route_data and save to cache
             stops_data = {
-                'City': next((variant for variant in route_data[line] 
-                            if variant['direction'] == 'City'), {}),
-                'Suburb': next((variant for variant in route_data[line] 
-                              if variant['direction'] == 'Suburb'), {})
+                "City": next(
+                    (
+                        variant
+                        for variant in route_data[line]
+                        if variant["direction"] == "City"
+                    ),
+                    {},
+                ),
+                "Suburb": next(
+                    (
+                        variant
+                        for variant in route_data[line]
+                        if variant["direction"] == "Suburb"
+                    ),
+                    {},
+                ),
             }
-            
+
             # Ensure cache directory exists
             os.makedirs(os.path.dirname(cache_path), exist_ok=True)
-            
+
             # Save to cache
-            with open(cache_path, 'w') as f:
-                json.dump({'stops': stops_data}, f)
-            
+            with open(cache_path, "w") as f:
+                json.dump({"stops": stops_data}, f)
+
             return stops_data
         else:
             logger.error(f"Failed to fetch route data for line {line}")
@@ -108,6 +120,7 @@ async def load_line_stops(line: str) -> Dict:
     except Exception as e:
         logger.error(f"Error loading stops for line {line}: {e}")
         return {}
+
 
 async def validate_line_stops(line):
     try:
@@ -119,43 +132,47 @@ async def validate_line_stops(line):
 
         variants = []
         for variant in route_data[line]:
-            if 'stops' not in variant:
+            if "stops" not in variant:
                 logger.warning(f"No stops data found for line {line} variant")
                 continue
-                
+
             try:
-                stops = variant['stops']
-                direction = variant.get('direction', 'Unknown')
-                destination = variant.get('destination', {'fr': 'Unknown'})
-                
-                variants.append(RouteVariant(
-                    line=line,
-                    direction=direction,
-                    destination=destination,
-                    stops=stops
-                ))
+                stops = variant["stops"]
+                direction = variant.get("direction", "Unknown")
+                destination = variant.get("destination", {"fr": "Unknown"})
+
+                variants.append(
+                    RouteVariant(
+                        line=line,
+                        direction=direction,
+                        destination=destination,
+                        stops=stops,
+                    )
+                )
             except Exception as e:
                 logger.error(f"Error processing variant for line {line}: {e}")
                 continue
-                
+
         return variants
-        
+
     except Exception as e:
         logger.error(f"Error validating stops for line {line}: {e}")
         return []
 
+
 def load_json_file(file_path: str) -> Dict:
     """Load a JSON file and return its contents as a dictionary"""
     try:
-        with open(file_path, 'r') as f:
+        with open(file_path, "r") as f:
             return json.load(f)
     except FileNotFoundError:
         logger.warning(f"File {file_path} not found, creating empty cache")
         # Create empty cache file
-        with open(file_path, 'w') as f:
+        with open(file_path, "w") as f:
             json.dump({}, f)
         logger.info(f"Created empty {file_path} file")
         return {}
+
 
 def load_route_shape(line: str, direction: str = None) -> List[List[float]]:
     """
@@ -163,127 +180,149 @@ def load_route_shape(line: str, direction: str = None) -> List[List[float]]:
     Returns list of [lon, lat] coordinates for the specified direction.
     """
     try:
-        shape_data = load_json_file(f'cache/shapes/line_{line}.json')
-        if not shape_data or 'variants' not in shape_data:
+        shape_data = load_json_file(f"cache/shapes/line_{line}.json")
+        if not shape_data or "variants" not in shape_data:
             logger.error(f"No valid shape data found for line {line}")
             return []
 
         # Find the correct variant based on direction
-        variants = shape_data['variants']
+        variants = shape_data["variants"]
         variant = None
-        
+
         if direction:
             variant = next(
-                (v for v in variants if 
-                 (v['variante'] == 2 and direction == 'City') or
-                 (v['variante'] == 1 and direction == 'Suburb')),
-                None
+                (
+                    v
+                    for v in variants
+                    if (v["variante"] == 2 and direction == "City")
+                    or (v["variante"] == 1 and direction == "Suburb")
+                ),
+                None,
             )
         else:
             # If no direction specified, use the first variant
             variant = variants[0] if variants else None
 
         if not variant:
-            logger.error(f"No matching variant found for line {line} direction {direction}")
+            logger.error(
+                f"No matching variant found for line {line} direction {direction}"
+            )
             return []
 
-        coordinates = variant.get('coordinates', [])
+        coordinates = variant.get("coordinates", [])
         if not coordinates:
             logger.error(f"No coordinates found in shape data for line {line}")
             return []
 
-        logger.debug(f"Loaded {len(coordinates)} coordinates for line {line} direction {direction}")
+        logger.debug(
+            f"Loaded {len(coordinates)} coordinates for line {line} direction {direction}"
+        )
         return coordinates
 
     except Exception as e:
         logger.error(f"Error loading shape for line {line}: {str(e)}")
         import traceback
+
         logger.error(f"Full traceback:\n{traceback.format_exc()}")
         return []
 
-def point_to_line_distance(point: Tuple[float, float], 
-                          line_start: Tuple[float, float], 
-                          line_end: Tuple[float, float]) -> float:
+
+def point_to_line_distance(
+    point: Tuple[float, float],
+    line_start: Tuple[float, float],
+    line_end: Tuple[float, float],
+) -> float:
     """Calculate the shortest distance from a point to a line segment"""
     # Convert to x,y coordinates (simplified, assuming small distances)
     px, py = point[1], point[0]  # lon, lat
     x1, y1 = line_start[1], line_start[0]
     x2, y2 = line_end[1], line_end[0]
-    
+
     # Calculate line segment length squared
-    line_length_sq = (x2 - x1)**2 + (y2 - y1)**2
-    
+    line_length_sq = (x2 - x1) ** 2 + (y2 - y1) ** 2
+
     if line_length_sq == 0:
         # Line segment is actually a point
-        return sqrt((px - x1)**2 + (py - y1)**2)
-    
+        return sqrt((px - x1) ** 2 + (py - y1) ** 2)
+
     # Calculate projection point parameter
     t = max(0, min(1, ((px - x1) * (x2 - x1) + (py - y1) * (y2 - y1)) / line_length_sq))
-    
+
     # Calculate closest point on line segment
     proj_x = x1 + t * (x2 - x1)
     proj_y = y1 + t * (y2 - y1)
-    
-    # Calculate distance
-    return sqrt((px - proj_x)**2 + (py - proj_y)**2)
 
-def validate_stops_on_route(variant: RouteVariant, shape_coords: List[List[float]], max_distance: float = 0.001) -> List[Dict]:
+    # Calculate distance
+    return sqrt((px - proj_x) ** 2 + (py - proj_y) ** 2)
+
+
+def validate_stops_on_route(
+    variant: RouteVariant, shape_coords: List[List[float]], max_distance: float = 0.001
+) -> List[Dict]:
     """
     Validate that stops are near the route line
     max_distance is in degrees (approximately 111m per 0.001 degrees at the equator)
     """
     issues = []
-    
+
     # For each stop
     for stop in variant.stops:
-        min_distance = float('inf')
+        min_distance = float("inf")
         stop_coords = (stop.coordinates[0], stop.coordinates[1])
-        
+
         # Check distance to each line segment
         for i in range(len(shape_coords) - 1):
             start_point = shape_coords[i]
             end_point = shape_coords[i + 1]
-            
+
             distance = point_to_line_distance(
                 stop_coords,
                 (start_point[1], start_point[0]),  # lat, lon
-                (end_point[1], end_point[0])
+                (end_point[1], end_point[0]),
             )
-            
+
             min_distance = min(min_distance, distance)
-        
+
         if min_distance > max_distance:
-            issues.append({
-                'stop_id': stop.id,
-                'stop_name': stop.name,
-                'distance': min_distance * 111000,  # Convert to approximate meters
-                'coordinates': stop_coords
-            })
-    
+            issues.append(
+                {
+                    "stop_id": stop.id,
+                    "stop_name": stop.name,
+                    "distance": min_distance * 111000,  # Convert to approximate meters
+                    "coordinates": stop_coords,
+                }
+            )
+
     return issues
+
 
 async def validate_line(line: str):
     """Validate all stops for a line against its route shapes"""
     variants = await validate_line_stops(line)
     shapes = load_route_shape(line)
-    
+
     for variant in variants:
         # Match variant with shape (variant 2 = City, variant 1 = Suburb)
         shape_variant = next(
-            (s for s in shapes if 
-             (s['variante'] == 2 and variant.direction == 'City') or
-             (s['variante'] == 1 and variant.direction == 'Suburb')),
-            None
+            (
+                s
+                for s in shapes
+                if (s["variante"] == 2 and variant.direction == "City")
+                or (s["variante"] == 1 and variant.direction == "Suburb")
+            ),
+            None,
         )
-        
+
         if not shape_variant:
             logger.error(f"No matching shape found for line {line} {variant.direction}")
             continue
-            
-        issues = validate_stops_on_route(variant, shape_variant['coordinates'])
-        
+
+        issues = validate_stops_on_route(variant, shape_variant["coordinates"])
+
         if issues:
-            logger.warning(f"\nLine {line} {variant.direction} has stops far from route:")
+            logger.warning(
+                f"\nLine {line} {variant.direction} has stops far from route:"
+            )
             for issue in issues:
                 logger.warning(
                     f"  {issue['stop_name']} (ID: {issue['stop_id']}) "
@@ -292,6 +331,7 @@ async def validate_line(line: str):
         else:
             logger.debug(f"\nLine {line} {variant.direction}: All stops are on route")
 
+
 def get_terminus_stops(line: str) -> Dict[str, Dict]:
     """
     Get terminus stop IDs for each direction of a line.
@@ -299,51 +339,54 @@ def get_terminus_stops(line: str) -> Dict[str, Dict]:
     """
     variants = validate_line_stops(line)
     terminus_map = {}
-    
+
     for variant in variants:
         if not variant.stops:
             logger.error(f"No stops found for line {line} {variant.direction}")
             continue
-            
+
         # Get both first and last stops of route
         first_stop = variant.stops[0]
         last_stop = variant.stops[-1]
-        
+
         # Add both terminus stops to the map with all necessary info as a dictionary
         terminus_map[first_stop.id] = {
-            'stop_id': first_stop.id,
-            'stop_name': first_stop.name,
-            'direction': variant.direction,
-            'destination': variant.destination
+            "stop_id": first_stop.id,
+            "stop_name": first_stop.name,
+            "direction": variant.direction,
+            "destination": variant.destination,
         }
-        
+
         terminus_map[last_stop.id] = {
-            'stop_id': last_stop.id,
-            'stop_name': last_stop.name,
-            'direction': variant.direction,
-            'destination': variant.destination
+            "stop_id": last_stop.id,
+            "stop_name": last_stop.name,
+            "direction": variant.direction,
+            "destination": variant.destination,
         }
-        
+
         logger.debug(f"\nLine {line} {variant.direction}:")
         logger.debug(f"  Start terminus: {first_stop.name} (ID: {first_stop.id})")
         logger.debug(f"  End terminus: {last_stop.name} (ID: {last_stop.id})")
-        logger.debug(f"  Heading to: {variant.destination['fr']} / {variant.destination['nl']}")
-    
+        logger.debug(
+            f"  Heading to: {variant.destination['fr']} / {variant.destination['nl']}"
+        )
+
     return terminus_map
+
 
 if __name__ == "__main__":
     # Test with lines 56 and 59
-    for line in ['56', '59', '64']:
+    for line in ["56", "59", "64"]:
         logger.info(f"\n=== Validating line {line} ===")
         validate_line(line)
-        
+
     # Test with all lines
     all_terminus = {}
-    for line in ['56', '59', '64']:
+    for line in ["56", "59", "64"]:
         logger.info(f"\n=== Analyzing terminus stops for line {line} ===")
         terminus_stops = get_terminus_stops(line)
         all_terminus[line] = terminus_stops
-        
+
     # Print summary
     logger.info("\n=== Terminus Summary ===")
     for line, terminus_data in all_terminus.items():


### PR DESCRIPTION
Fix #38 by centralising logging settings.

Remove an issue with double initialisation of provdiers:
There were two causes:
Double import in app/__init__.py
No check for existing provider registration in provider initialization code

These are fixed by:
Removing the duplicate import in app/__init__.py
Adding checks in each provider's __init__.py to prevent double initialization