### PR TITLE
STIB: Mobility Open Data APIM (subscription key, URLs)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,11 @@
 # API Keys for various transit providers
+# Belgian Mobility Open Data Portal (STIB/De Lijn/SNCB/TEC datasets on Azure APIM):
+# https://api-management-opendata-production.developer.azure-api.net/
+MOBILITY_API_PRIMARY_KEY=your-mobility-primary-subscription-key
+MOBILITY_API_SECONDARY_KEY=your-mobility-secondary-subscription-key
+# Optional: override gateway host (default: api-management-opendata-production.azure-api.net)
+# MOBILITY_APIM_BASE_URL=https://api-management-opendata-production.azure-api.net
+# Legacy OpenDataSoft token (optional fallback if mobility keys are unset)
 STIB_API_KEY=your-stib-api-key-here
 DELIJN_API_KEY=your-delijn-api-key-here
 DELIJN_GTFS_STATIC_API_KEY=your-delijn-gtfs-static-key-here

--- a/app/config/default.py
+++ b/app/config/default.py
@@ -160,8 +160,17 @@ PROVIDER_CONFIG = {
     "stib": {
         "provider_specific": {
             "API_KEY": os.getenv("STIB_API_KEY"),
+            "MOBILITY_API_PRIMARY_KEY": os.getenv("MOBILITY_API_PRIMARY_KEY"),
+            "MOBILITY_API_SECONDARY_KEY": os.getenv("MOBILITY_API_SECONDARY_KEY"),
             "_AVAILABLE_LANGUAGES": ["en", "fr", "nl"],
-            "API_URL": "https://data.stib-mivb.brussels/api/explore/v2.1/catalog/datasets",
+            # Dataset URLs: transit_providers/be/stib/config.py (Belgian Mobility APIM)
+            "API_URL": (
+                os.getenv(
+                    "MOBILITY_APIM_BASE_URL",
+                    "https://api-management-opendata-production.azure-api.net",
+                ).rstrip("/")
+                + "/api/datasets/stibmivb"
+            ),
             "GTFS_DIR": PROJECT_ROOT / "cache" / "stib" / "gtfs",
             "CACHE_DIR": PROJECT_ROOT / "cache" / "stib",
             "STOPS_CACHE_FILE": PROJECT_ROOT / "cache" / "stib" / "stops.json",

--- a/app/conftest.py
+++ b/app/conftest.py
@@ -1,0 +1,9 @@
+"""Pytest: PROJECT_ROOT required by provider config modules."""
+
+import os
+from pathlib import Path
+
+os.environ.setdefault(
+    "PROJECT_ROOT",
+    str(Path(__file__).resolve().parent),
+)

--- a/app/transit_providers/be/stib/__init__.py
+++ b/app/transit_providers/be/stib/__init__.py
@@ -11,6 +11,7 @@ import logging
 from transit_providers import TransitProvider, register_provider, PROVIDERS
 from .gtfs import ensure_gtfs_data
 from .get_stop_names import get_stop_names as get_stop_names_from_backend
+from .mobility import mobility_subscription_headers
 from flask import request
 import asyncio
 
@@ -196,16 +197,17 @@ class StibProvider(TransitProvider):
 
             # If not found in cache or GTFS, try API
             if not coordinates:
-                # Get stop details from STIB API
+                # Get stop details from STIB API (Belgian Mobility portal)
                 params = {
-                    "apikey": self.config.get("API_KEY"),
                     "where": f'id="{stop_id}"',
                     "limit": 1,
                 }
 
                 async with await get_client() as client:
                     response = await client.get(
-                        self.config.get("STOPS_API_URL"), params=params
+                        self.config.get("STIB_STOPS_API_URL"),
+                        params=params,
+                        headers=mobility_subscription_headers(),
                     )
                     if response.status_code == 200:
                         data = response.json()

--- a/app/transit_providers/be/stib/api.py
+++ b/app/transit_providers/be/stib/api.py
@@ -348,6 +348,16 @@ def _route_colors_from_gtfs(
     return out
 
 
+def _utc_now() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _to_utc_aware(ts: datetime) -> datetime:
+    if ts.tzinfo is None:
+        return ts.replace(tzinfo=timezone.utc)
+    return ts.astimezone(timezone.utc)
+
+
 async def get_route_colors(monitored_lines=None):
     """Fetch route colors with caching"""
     # If monitored_lines is a string (single line number), convert it to a list
@@ -365,9 +375,13 @@ async def get_route_colors(monitored_lines=None):
             with open(ROUTES_CACHE_FILE, "r") as f:
                 cache_data = json.load(f)
                 routes_cache["data"] = cache_data.get("data", {})
-                routes_cache["timestamp"] = datetime.fromisoformat(
-                    cache_data.get("timestamp", "")
-                )
+                raw_ts = cache_data.get("timestamp", "") or ""
+                if raw_ts:
+                    routes_cache["timestamp"] = _to_utc_aware(
+                        datetime.fromisoformat(raw_ts)
+                    )
+                else:
+                    routes_cache["timestamp"] = None
                 logger.debug(
                     f"Loaded route colors from file cache: {routes_cache.get('data', 'Error no data in cache')}"
                 )
@@ -381,7 +395,7 @@ async def get_route_colors(monitored_lines=None):
     if (
         routes_cache["timestamp"]
         and routes_cache["data"]
-        and datetime.now() - routes_cache["timestamp"] < CACHE_DURATION
+        and _utc_now() - routes_cache["timestamp"] < CACHE_DURATION
         and (
             not monitored_lines
             or all(line in routes_cache["data"] for line in monitored_lines)
@@ -416,22 +430,25 @@ async def get_route_colors(monitored_lines=None):
             )
             data_for_cache = route_colors
 
-        routes_cache["timestamp"] = datetime.now()
+        routes_cache["timestamp"] = _utc_now()
         routes_cache["data"] = data_for_cache
 
-        try:
-            with open(ROUTES_CACHE_FILE, "w") as f:
-                json.dump(
-                    {
-                        "timestamp": routes_cache["timestamp"].isoformat(),
-                        "data": data_for_cache,
-                    },
-                    f,
-                )
-        except Exception as e:
-            import traceback
+        def _write_routes_cache() -> None:
+            try:
+                with open(ROUTES_CACHE_FILE, "w") as f:
+                    json.dump(
+                        {
+                            "timestamp": routes_cache["timestamp"].isoformat(),
+                            "data": data_for_cache,
+                        },
+                        f,
+                    )
+            except Exception as e:
+                import traceback
 
-            logger.error(f"Error saving routes cache: {e}\n{traceback.format_exc()}")
+                logger.error(f"Error saving routes cache: {e}\n{traceback.format_exc()}")
+
+        await asyncio.to_thread(_write_routes_cache)
 
         return route_colors
 
@@ -444,13 +461,13 @@ async def get_route_colors(monitored_lines=None):
             if ROUTES_CACHE_FILE.exists():
                 with open(ROUTES_CACHE_FILE, "r") as f:
                     cache_data = json.load(f)
-                    cache_timestamp = datetime.fromisoformat(
-                        cache_data.get("timestamp", "")
+                    raw_fallback = cache_data.get("timestamp", "") or ""
+                    if not raw_fallback:
+                        raise ValueError("missing cache timestamp")
+                    cache_timestamp = _to_utc_aware(
+                        datetime.fromisoformat(raw_fallback)
                     )
-                    if (
-                        cache_timestamp
-                        and datetime.now() - cache_timestamp < CACHE_DURATION
-                    ):
+                    if _utc_now() - cache_timestamp < CACHE_DURATION:
                         return cache_data.get("data", {})
         except Exception as cache_e:
             logger.error(

--- a/app/transit_providers/be/stib/api.py
+++ b/app/transit_providers/be/stib/api.py
@@ -358,6 +358,15 @@ def _to_utc_aware(ts: datetime) -> datetime:
     return ts.astimezone(timezone.utc)
 
 
+def _route_colors_subset(
+    data: Dict[str, str], monitored_lines: Optional[List[str]]
+) -> Dict[str, str]:
+    """Return full cache when unfiltered; only requested lines when filtered."""
+    if not monitored_lines:
+        return data
+    return {ln: data[ln] for ln in monitored_lines if ln in data}
+
+
 async def get_route_colors(monitored_lines=None):
     """Fetch route colors with caching"""
     # If monitored_lines is a string (single line number), convert it to a list
@@ -402,7 +411,7 @@ async def get_route_colors(monitored_lines=None):
         )
     ):
         logger.debug("Using cached route colors")
-        return routes_cache["data"]
+        return _route_colors_subset(routes_cache["data"], monitored_lines)
 
     logger.debug("Loading route colors from GTFS (routes.txt)")
     gtfs_path = Path(GTFS_DIR) if GTFS_DIR else Path()
@@ -468,7 +477,9 @@ async def get_route_colors(monitored_lines=None):
                         datetime.fromisoformat(raw_fallback)
                     )
                     if _utc_now() - cache_timestamp < CACHE_DURATION:
-                        return cache_data.get("data", {})
+                        return _route_colors_subset(
+                            cache_data.get("data", {}), monitored_lines
+                        )
         except Exception as cache_e:
             logger.error(
                 f"Error loading routes cache: {cache_e}\n{traceback.format_exc()}"

--- a/app/transit_providers/be/stib/api.py
+++ b/app/transit_providers/be/stib/api.py
@@ -1,4 +1,5 @@
 import os
+import csv
 from config import get_config
 import json
 from datetime import datetime, timezone, timedelta
@@ -32,6 +33,7 @@ from .locate_vehicles import (
     validate_segment,
 )
 from .validate_stops import validate_line_stops, load_route_shape
+from .mobility import mobility_subscription_headers
 
 # Get logger
 logger = logging.getLogger("stib")
@@ -47,16 +49,15 @@ MESSAGES_API_URL = provider_config.get("STIB_MESSAGES_API_URL", "")
 logger.debug(f"MESSAGES_API_URL: {MESSAGES_API_URL}")
 WAITING_TIMES_API_URL = provider_config.get("STIB_WAITING_TIME_API_URL", "")
 logger.debug(f"WAITING_TIMES_API_URL: {WAITING_TIMES_API_URL}")
+VEHICLE_POSITIONS_API_URL = provider_config.get("STIB_VEHICLE_POSITIONS_API_URL", "")
 GTFS_URL = provider_config.get("GTFS_URL", "")
-GTFS_DIR = get_config("GTFS_DIR")
+GTFS_DIR = provider_config.get("GTFS_DIR")
 CACHE_DIR = get_config("CACHE_DIR")
 SHAPES_CACHE_DIR = CACHE_DIR / "shapes"
 
 # Initialize caches
 _last_waiting_times_result = None
 
-# API keys
-API_KEY = provider_config.get("API_KEY")
 # Configuration
 STIB_STOPS = provider_config.get("STIB_STOPS")
 TIMEZONE = pytz.timezone(get_config("TIMEZONE"))
@@ -188,9 +189,8 @@ async def get_service_messages(monitored_lines=None, monitored_stops=None):
             filters.extend(line_filters)
             logger.debug(f"Added {len(line_filters)} line filters")
 
-        # Build query parameters
+        # Build query parameters (Azure APIM + Explore-compatible dataset API)
         params = {
-            "apikey": API_KEY,
             "limit": 100,  # Get a reasonable number of messages
             "select": "content,lines,points,priority,type",  # Only get fields we need
         }
@@ -203,7 +203,11 @@ async def get_service_messages(monitored_lines=None, monitored_stops=None):
 
         # Make API request
         async with await get_client() as client:
-            response = await client.get(MESSAGES_API_URL, params=params)
+            response = await client.get(
+                MESSAGES_API_URL,
+                params=params,
+                headers=mobility_subscription_headers(),
+            )
             rate_limiter.update_from_headers(response.headers)
 
             if response.status_code != 200:
@@ -323,6 +327,27 @@ class WaitingTimesCache:
     data: Dict[str, Any]
 
 
+def _route_colors_from_gtfs(
+    gtfs_dir: Path, monitored_lines: Optional[List[str]]
+) -> Dict[str, str]:
+    """Map route_short_name to #RRGGBB from GTFS routes.txt (Belgian Mobility static feed)."""
+    routes_file = gtfs_dir / "routes.txt"
+    out: Dict[str, str] = {}
+    if not routes_file.is_file():
+        return out
+    want = {str(x) for x in monitored_lines} if monitored_lines else None
+    with open(routes_file, newline="", encoding="utf-8") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            num = (row.get("route_short_name") or "").strip()
+            if want is not None and num not in want:
+                continue
+            color = (row.get("route_color") or "").strip()
+            if num and color:
+                out[num] = f"#{color}"
+    return out
+
+
 async def get_route_colors(monitored_lines=None):
     """Fetch route colors with caching"""
     # If monitored_lines is a string (single line number), convert it to a list
@@ -365,57 +390,41 @@ async def get_route_colors(monitored_lines=None):
         logger.debug("Using cached route colors")
         return routes_cache["data"]
 
-    logger.debug("Fetching fresh route colors")
-    url = "https://stibmivb.opendatasoft.com/api/explore/v2.1/catalog/datasets/gtfs-routes-production/records"
-
-    params = {"limit": 100, "apikey": API_KEY}  # Get all routes
-
-    # Add filter if we have specific lines we're interested in
-    if monitored_lines:
-        conditions = [f'route_short_name="{line}"' for line in monitored_lines]
-        params["where"] = " or ".join(conditions)
-
+    logger.debug("Loading route colors from GTFS (routes.txt)")
+    gtfs_path = Path(GTFS_DIR) if GTFS_DIR else Path()
     try:
-        async with await get_client() as client:
-            # Check rate limits before making request
-            if not rate_limiter.can_make_request():
-                logger.warning("Rate limit exceeded, using cached colors")
-                return routes_cache.get("data", {})
-            response = await client.get(url, params=params)
-            # Update rate limits from response headers
-            rate_limiter.update_from_headers(response.headers)
+        if not gtfs_path.is_dir() or not (gtfs_path / "routes.txt").is_file():
+            logger.info("GTFS routes.txt missing; downloading static feed")
+            await asyncio.to_thread(download_gtfs_data)
 
-            data = response.json()
+        if not gtfs_path.is_dir() or not (gtfs_path / "routes.txt").is_file():
+            logger.error("Could not load routes.txt for route colors")
+            raise FileNotFoundError("routes.txt")
 
-            # Create dictionary mapping route numbers to colors
-            for route in data["results"]:
-                route_number = route["route_short_name"]
-                route_color = route.get("route_color", "")
-                if route_color:
-                    route_colors[route_number] = f"#{route_color}"
+        route_colors = await asyncio.to_thread(
+            _route_colors_from_gtfs,
+            gtfs_path,
+            list(monitored_lines) if monitored_lines else None,
+        )
 
-            # Update cache
-            routes_cache["timestamp"] = datetime.now()
-            routes_cache["data"] = route_colors
+        routes_cache["timestamp"] = datetime.now()
+        routes_cache["data"] = route_colors
 
-            # Also save to file cache
-            try:
-                with open(ROUTES_CACHE_FILE, "w") as f:
-                    json.dump(
-                        {
-                            "timestamp": routes_cache["timestamp"].isoformat(),
-                            "data": route_colors,
-                        },
-                        f,
-                    )
-            except Exception as e:
-                import traceback
-
-                logger.error(
-                    f"Error saving routes cache: {e}\n{traceback.format_exc()}"
+        try:
+            with open(ROUTES_CACHE_FILE, "w") as f:
+                json.dump(
+                    {
+                        "timestamp": routes_cache["timestamp"].isoformat(),
+                        "data": route_colors,
+                    },
+                    f,
                 )
+        except Exception as e:
+            import traceback
 
-            return route_colors
+            logger.error(f"Error saving routes cache: {e}\n{traceback.format_exc()}")
+
+        return route_colors
 
     except Exception as e:
         import traceback
@@ -484,10 +493,12 @@ async def get_vehicle_positions(line: str = None, direction: str = None):
         # The correct filter syntax for the API
         lines_filter = " or ".join([f'lineid="{line}"' for line in monitored_lines])
 
-        params = {"where": f"({lines_filter})", "limit": 100, "apikey": API_KEY}
+        params = {"where": f"({lines_filter})", "limit": 100}
 
         async with await get_client() as client:
-            base_url = "https://data.stib-mivb.brussels/api/explore/v2.1/catalog/datasets/vehicle-position-rt-production/records"
+            if not VEHICLE_POSITIONS_API_URL:
+                logger.error("STIB_VEHICLE_POSITIONS_API_URL is not configured")
+                return {"vehicles": []}
             # Check if we've exceeded quota or have low remaining requests
             if not rate_limiter.can_make_request() or (
                 rate_limiter.remaining is not None and rate_limiter.remaining < 1000
@@ -497,7 +508,11 @@ async def get_vehicle_positions(line: str = None, direction: str = None):
                 )
                 return {"vehicles": []}
 
-            response = await client.get(base_url, params=params)
+            response = await client.get(
+                VEHICLE_POSITIONS_API_URL,
+                params=params,
+                headers=mobility_subscription_headers(),
+            )
             # Update rate limits from response headers
             rate_limiter.update_from_headers(response.headers)
 
@@ -678,7 +693,7 @@ async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict[str, 
         # Check if we have a recent result
         now = datetime.now(timezone.utc)
         cache_key = str(stop_id) if stop_id else "all"
-        
+
         async with lock:
             if cache_key in waiting_times_cache:
                 cache_entry = waiting_times_cache[cache_key]
@@ -692,14 +707,19 @@ async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict[str, 
                                     if "message" not in time_entry:
                                         # Parse the expected arrival time
                                         arrival_dt = datetime.fromisoformat(
-                                            time_entry["_raw_arrival_time"].replace("Z", "+00:00")
+                                            time_entry["_raw_arrival_time"].replace(
+                                                "Z", "+00:00"
+                                            )
                                         )
                                         # Calculate new minutes
                                         minutes = max(
-                                            0, int((arrival_dt - now).total_seconds() / 60)
+                                            0,
+                                            int(
+                                                (arrival_dt - now).total_seconds() / 60
+                                            ),
                                         )
                                         time_entry["minutes"] = minutes
-                    
+
                     logger.debug(f"Using cached waiting times for {cache_key}")
                     return cached_data
 
@@ -710,8 +730,12 @@ async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict[str, 
                     "stops_data": {},
                     "error": "Rate limit exceeded",
                     "rate_limit_exceeded": True,
-                    "reset_time": rate_limiter.reset_time.isoformat() if rate_limiter.reset_time else None,
-                    "remaining": rate_limiter.remaining
+                    "reset_time": (
+                        rate_limiter.reset_time.isoformat()
+                        if rate_limiter.reset_time
+                        else None
+                    ),
+                    "remaining": rate_limiter.remaining,
                 }
 
             # Get monitored stops from merged config
@@ -724,7 +748,6 @@ async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict[str, 
 
             # Build API query
             params = {
-                "apikey": API_KEY,
                 "limit": 100,
                 "select": "pointid,lineid,passingtimes",
             }
@@ -763,14 +786,21 @@ async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict[str, 
             # Otherwise filter for all monitored stops
             elif monitored_stops:
                 stop_filter = " or ".join(
-                    f'pointid="{normalized_id}"' for normalized_id in monitored_stops.keys()
+                    f'pointid="{normalized_id}"'
+                    for normalized_id in monitored_stops.keys()
                 )
                 params["where"] = f"({stop_filter})"
-                params["limit"] = 100  # Make sure we get all results for monitored stops
+                params["limit"] = (
+                    100  # Make sure we get all results for monitored stops
+                )
                 logger.debug(f"Using monitored stops: {list(monitored_stops.keys())}")
 
             async with await get_client() as client:
-                response = await client.get(WAITING_TIMES_API_URL, params=params)
+                response = await client.get(
+                    WAITING_TIMES_API_URL,
+                    params=params,
+                    headers=mobility_subscription_headers(),
+                )
                 rate_limiter.update_from_headers(response.headers)
 
                 if response.status_code != 200:
@@ -797,7 +827,10 @@ async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict[str, 
                             )
                             continue
                         # Otherwise only process monitored stops
-                        elif not requested_stops and current_stop_id not in monitored_stops:
+                        elif (
+                            not requested_stops
+                            and current_stop_id not in monitored_stops
+                        ):
                             logger.debug(
                                 f"Skipping stop {current_stop_id} - not in monitored stops"
                             )
@@ -827,7 +860,9 @@ async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict[str, 
                             stop_name = (
                                 monitored_stops[current_stop_id]["name"]
                                 if current_stop_id in monitored_stops
-                                else get_stop_names([response_stop_id])[response_stop_id]["name"]
+                                else get_stop_names([response_stop_id])[
+                                    response_stop_id
+                                ]["name"]
                             )
 
                             # Get coordinates for this stop (use original ID for coordinates lookup)
@@ -901,7 +936,9 @@ async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict[str, 
                                     # Check if this destination is allowed for this line
                                     allowed_destinations = allowed_lines[line]
                                     if allowed_destinations and not any(
-                                        matches_destination(allowed_dest, destination_data)
+                                        matches_destination(
+                                            allowed_dest, destination_data
+                                        )
                                         for allowed_dest in allowed_destinations
                                     ):
                                         logger.warning(
@@ -913,23 +950,23 @@ async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict[str, 
                                 # Initialize line data if needed
                                 if (
                                     line
-                                    not in formatted_data["stops_data"][response_stop_id][
-                                        "lines"
-                                    ]
+                                    not in formatted_data["stops_data"][
+                                        response_stop_id
+                                    ]["lines"]
                                 ):
-                                    formatted_data["stops_data"][response_stop_id]["lines"][
-                                        line
-                                    ] = {}
+                                    formatted_data["stops_data"][response_stop_id][
+                                        "lines"
+                                    ][line] = {}
 
                                 if (
                                     destination
-                                    not in formatted_data["stops_data"][response_stop_id][
-                                        "lines"
-                                    ][line]
+                                    not in formatted_data["stops_data"][
+                                        response_stop_id
+                                    ]["lines"][line]
                                 ):
-                                    formatted_data["stops_data"][response_stop_id]["lines"][
-                                        line
-                                    ][destination] = []
+                                    formatted_data["stops_data"][response_stop_id][
+                                        "lines"
+                                    ][line][destination] = []
 
                                 # Calculate minutes until arrival
                                 expected_time = passing_time.get("expectedArrivalTime")
@@ -947,15 +984,17 @@ async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict[str, 
                                         0, int((arrival_dt - now).total_seconds() / 60)
                                     )
 
-                                    formatted_data["stops_data"][response_stop_id]["lines"][
-                                        line
-                                    ][destination].append(
+                                    formatted_data["stops_data"][response_stop_id][
+                                        "lines"
+                                    ][line][destination].append(
                                         {
                                             "destination": destination,
                                             "destination_data": destination_data,  # Keep all language versions
                                             "minutes": minutes,
                                             "message": passing_time.get("message", ""),
-                                            "formatted_time": arrival_dt.strftime("%H:%M"),
+                                            "formatted_time": arrival_dt.strftime(
+                                                "%H:%M"
+                                            ),
                                             "_raw_arrival_time": expected_time,  # Store for recalculation
                                             "_metadata": {
                                                 "language": _metadata["language"]
@@ -988,7 +1027,7 @@ async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict[str, 
                 # Cache the result
                 waiting_times_cache[cache_key] = {
                     "timestamp": now,
-                    "data": formatted_data
+                    "data": formatted_data,
                 }
 
                 return formatted_data
@@ -1011,9 +1050,6 @@ async def get_route_data(line: str) -> Dict[str, Any]:
         Dictionary containing route variants with stops and shapes
     """
     try:
-        # Get route variants from validate_stops
-        from validate_stops import validate_line_stops, load_route_shape
-
         route_variants = await validate_line_stops(line)
 
         if not route_variants:
@@ -1045,10 +1081,12 @@ async def get_route_data(line: str) -> Dict[str, Any]:
 
 async def ensure_gtfs_data() -> Optional[Path]:
     """Ensure GTFS data is downloaded and return path to GTFS directory."""
-    if not GTFS_DIR.exists() or not (GTFS_DIR / "stops.txt").exists():
+    if not GTFS_DIR or not GTFS_DIR.exists() or not (GTFS_DIR / "stops.txt").exists():
         logger.info("GTFS data not found, downloading...")
-        await download_gtfs_data()
-    return GTFS_DIR
+        await asyncio.to_thread(download_gtfs_data)
+    if GTFS_DIR and (GTFS_DIR / "stops.txt").exists():
+        return GTFS_DIR
+    return None
 
 
 async def get_stops() -> Dict[str, Stop]:
@@ -1120,37 +1158,6 @@ def get_nearest_stop(coordinates: Tuple[float, float]) -> Dict[str, Any]:
     lat, lon = coordinates
     stops = asyncio.run(find_nearest_stops(lat, lon, limit=1))
     return stops[0] if stops else {}
-
-
-async def get_stop_coordinates(self, stop_id: str) -> Optional[Dict[str, float]]:
-    """Get coordinates for a stop."""
-    try:
-        # Try to get coordinates from API first
-        url = f"{self.stops_api_url}?apikey={self.api_key}&where=id='{stop_id}'"
-        async with await get_client() as client:
-            response = await client.get(url)
-            if response.status_code != 200:
-                logger.error(
-                    f"Failed to get stop coordinates: {response.status_code} {response.text}"
-                )
-                return None
-
-            data = response.json()
-            results = data.get("results", [])
-            if not results:
-                logger.warning(f"No results found for stop {stop_id}")
-                return get_stop_coordinates_with_fallback(stop_id)
-
-            stop = results[0]
-            lat = stop.get("latitude")
-            lon = stop.get("longitude")
-
-            # Use GTFS fallback if API returns null coordinates
-            return get_stop_coordinates_with_fallback(stop_id, (lat, lon))
-
-    except Exception as e:
-        logger.error(f"Error getting stop coordinates: {e}")
-        return get_stop_coordinates_with_fallback(stop_id)
 
 
 def convert_v2_to_v1_format(v2_data: Dict[str, Any]) -> Dict[str, Any]:

--- a/app/transit_providers/be/stib/api.py
+++ b/app/transit_providers/be/stib/api.py
@@ -401,21 +401,30 @@ async def get_route_colors(monitored_lines=None):
             logger.error("Could not load routes.txt for route colors")
             raise FileNotFoundError("routes.txt")
 
-        route_colors = await asyncio.to_thread(
-            _route_colors_from_gtfs,
-            gtfs_path,
-            list(monitored_lines) if monitored_lines else None,
-        )
+        if monitored_lines:
+            route_colors = await asyncio.to_thread(
+                _route_colors_from_gtfs,
+                gtfs_path,
+                list(monitored_lines),
+            )
+            data_for_cache = await asyncio.to_thread(
+                _route_colors_from_gtfs, gtfs_path, None
+            )
+        else:
+            route_colors = await asyncio.to_thread(
+                _route_colors_from_gtfs, gtfs_path, None
+            )
+            data_for_cache = route_colors
 
         routes_cache["timestamp"] = datetime.now()
-        routes_cache["data"] = route_colors
+        routes_cache["data"] = data_for_cache
 
         try:
             with open(ROUTES_CACHE_FILE, "w") as f:
                 json.dump(
                     {
                         "timestamp": routes_cache["timestamp"].isoformat(),
-                        "data": route_colors,
+                        "data": data_for_cache,
                     },
                     f,
                 )

--- a/app/transit_providers/be/stib/config.py
+++ b/app/transit_providers/be/stib/config.py
@@ -50,7 +50,7 @@ DEFAULT_CONFIG = {
     "STIB_STOPS_BY_LINE_API_URL": mobility_url(
         "/api/datasets/stibmivb/static/stopsByLine"
     ),
-    "STIB_SHAPEFILES_API_URL": mobility_url(
+    "STIB_SHAPE_FILES_API_URL": mobility_url(
         "/api/datasets/stibmivb/static/shape-files"
     ),
     "GTFS_STATIC_FEED_URL": mobility_url("/api/gtfs/feed/stibmivb/static"),

--- a/app/transit_providers/be/stib/config.py
+++ b/app/transit_providers/be/stib/config.py
@@ -12,6 +12,8 @@ logger = logging.getLogger("stib")
 # Get project root from environment variable (set by start.py)
 PROJECT_ROOT = Path(os.environ["PROJECT_ROOT"])
 
+from .mobility import mobility_url
+
 # Register default configuration
 DEFAULT_CONFIG = {
     "STIB_STOPS": [
@@ -25,18 +27,34 @@ DEFAULT_CONFIG = {
             "direction": "City",  # or "Suburb"
         }  # Example stop, different from default.py to track config precedence
     ],
+    # Legacy app token (Open Data Soft); optional fallback if mobility keys unset
     "API_KEY": os.getenv("STIB_API_KEY"),
+    "MOBILITY_API_PRIMARY_KEY": os.getenv("MOBILITY_API_PRIMARY_KEY"),
+    "MOBILITY_API_SECONDARY_KEY": os.getenv("MOBILITY_API_SECONDARY_KEY"),
     "_AVAILABLE_LANGUAGES": [
         "en",
         "fr",
         "nl",
     ],  # Languages available in STIB API responses
-    "API_URL": "https://data.stib-mivb.brussels/api/explore/v2.1/catalog/datasets",
-    "STIB_API_URL_BASE": "https://data.stib-mivb.brussels/api/explore/v2.1/catalog/datasets",
-    "STIB_STOPS_API_URL": "https://data.stib-mivb.brussels/api/explore/v2.1/catalog/datasets/stop-details-production/records",
-    "STIB_WAITING_TIME_API_URL": "https://data.stib-mivb.brussels/api/explore/v2.1/catalog/datasets/waiting-time-rt-production/records",
-    "STIB_MESSAGES_API_URL": "https://data.stib-mivb.brussels/api/explore/v2.1/catalog/datasets/travellers-information-rt-production/records",
-    "GTFS_API_URL": "https://data.stib-mivb.brussels/api/explore/v2.1/catalog/datasets/gtfs-files-production/records",
+    # Belgian Mobility Open Data Portal (Azure APIM) — Explore-compatible dataset paths
+    "API_URL": mobility_url("/api/datasets/stibmivb"),
+    "STIB_API_URL_BASE": mobility_url("/api/datasets/stibmivb"),
+    "STIB_STOPS_API_URL": mobility_url("/api/datasets/stibmivb/static/stopDetails"),
+    "STIB_WAITING_TIME_API_URL": mobility_url("/api/datasets/stibmivb/rt/WaitingTimes"),
+    "STIB_MESSAGES_API_URL": mobility_url(
+        "/api/datasets/stibmivb/rt/TravellersInformation"
+    ),
+    "STIB_VEHICLE_POSITIONS_API_URL": mobility_url(
+        "/api/datasets/stibmivb/rt/VehiclePositions"
+    ),
+    "STIB_STOPS_BY_LINE_API_URL": mobility_url(
+        "/api/datasets/stibmivb/static/stopsByLine"
+    ),
+    "STIB_SHAPEFILES_API_URL": mobility_url(
+        "/api/datasets/stibmivb/static/shape-files"
+    ),
+    "GTFS_STATIC_FEED_URL": mobility_url("/api/gtfs/feed/stibmivb/static"),
+    "GTFS_API_URL": mobility_url("/api/gtfs/feed/stibmivb/static"),
     "GTFS_DIR": PROJECT_ROOT / "cache" / "stib" / "gtfs",
     "CACHE_DIR": PROJECT_ROOT / "cache" / "stib",
     "STOPS_CACHE_FILE": PROJECT_ROOT / "cache" / "stib" / "stops.json",

--- a/app/transit_providers/be/stib/get_stop_names.py
+++ b/app/transit_providers/be/stib/get_stop_names.py
@@ -441,7 +441,7 @@ def get_stop_names(stop_ids, preferred_language=None):
                         STOPS_API_URL,
                         params=params,
                         headers=sub_headers,
-                        timeout=10,
+                        timeout=30,
                     )
                     logger.debug(f"Batch API Response status: {response.status_code}")
 

--- a/app/transit_providers/be/stib/get_stop_names.py
+++ b/app/transit_providers/be/stib/get_stop_names.py
@@ -2,6 +2,7 @@
 
 import os
 import niquests as requests
+from niquests.exceptions import RequestException, Timeout as RequestsTimeout
 from pathlib import Path
 from datetime import timedelta, datetime
 import json
@@ -189,6 +190,30 @@ def get_stop_info_from_gtfs(stop_id: str) -> Optional[StopInfo]:
         return None
 
 
+def _mark_stops_failed(batch: List[str], cached_stops: Dict) -> None:
+    """Increment failure counters for every stop in batch (shared API error path)."""
+    for stop_id in batch:
+        failures = cached_stops.get(stop_id, {}).get("_failures", {})
+        if stop_id not in cached_stops:
+            cached_stops[stop_id] = {
+                "name": stop_id,
+                "names": {"fr": stop_id, "nl": stop_id},
+                "coordinates": {"lat": None, "lon": None},
+                "_metadata": {"source": "fallback"},
+                "_failures": {
+                    "count": failures.get("count", 0) + 1,
+                    "last_failure": datetime.now().isoformat(),
+                    "normalized_id": get_stop_id_variants(stop_id)[-1],
+                },
+            }
+        else:
+            cached_stops[stop_id]["_failures"] = {
+                "count": failures.get("count", 0) + 1,
+                "last_failure": datetime.now().isoformat(),
+                "normalized_id": get_stop_id_variants(stop_id)[-1],
+            }
+
+
 def should_retry_stop(stop_data):
     """Check if we should retry fetching a stop based on its failure history."""
     failures = stop_data.get("_failures", {})
@@ -372,198 +397,208 @@ def get_stop_names(stop_ids, preferred_language=None):
     if stops_to_fetch:
         logger.info(f"Fetching {len(stops_to_fetch)} stops from API")
 
-        # Process stops in batches
-        for i in range(0, len(stops_to_fetch), BATCH_SIZE):
-            batch = stops_to_fetch[i : i + BATCH_SIZE]
-            logger.debug(
-                f"Processing batch {i//BATCH_SIZE + 1}/{(len(stops_to_fetch) + BATCH_SIZE - 1)//BATCH_SIZE}"
-            )
-
-            # Build OR query for all stops in batch
-            variant_queries = []
-            for stop_id in batch:
-                variants = get_stop_id_variants(stop_id)
-                variant_queries.extend([f'id="{v}"' for v in variants])
-
-            query = " OR ".join(variant_queries)
-            params = {
-                "where": f"({query})",
-                "limit": len(
-                    variant_queries
-                ),  # Adjust limit to match number of variants
-            }
-
-            try:
-                response = requests.get(
-                    STOPS_API_URL,
-                    params=params,
-                    headers=mobility_subscription_headers(),
+        missing_url = not STOPS_API_URL
+        missing_key = not mobility_subscription_headers().get(
+            "Ocp-Apim-Subscription-Key"
+        )
+        if missing_url or missing_key:
+            if missing_url:
+                logger.error(
+                    "STIB_STOPS_API_URL is not configured; cannot fetch stop names"
                 )
-                logger.debug(f"Batch API Response status: {response.status_code}")
+            if missing_key:
+                logger.error(
+                    "MOBILITY_API_PRIMARY_KEY, MOBILITY_API_SECONDARY_KEY, or STIB_API_KEY "
+                    "is required for STIB stops API"
+                )
+            _mark_stops_failed(stops_to_fetch, cached_stops)
+            save_cached_stops(cached_stops)
+        else:
+            # Process stops in batches
+            for i in range(0, len(stops_to_fetch), BATCH_SIZE):
+                batch = stops_to_fetch[i : i + BATCH_SIZE]
+                logger.debug(
+                    f"Processing batch {i//BATCH_SIZE + 1}/{(len(stops_to_fetch) + BATCH_SIZE - 1)//BATCH_SIZE}"
+                )
 
-                if response.status_code != 200:
-                    logger.warning(f"Batch API Response text: {response.text}")
-                    # Mark all stops in batch as failed
-                    for stop_id in batch:
-                        failures = cached_stops.get(stop_id, {}).get("_failures", {})
-                        if stop_id not in cached_stops:
-                            cached_stops[stop_id] = {
-                                "name": stop_id,
-                                "names": {"fr": stop_id, "nl": stop_id},
-                                "coordinates": {"lat": None, "lon": None},
-                                "_metadata": {"source": "fallback"},
-                                "_failures": {
+                # Build OR query for all stops in batch
+                variant_queries = []
+                for stop_id in batch:
+                    variants = get_stop_id_variants(stop_id)
+                    variant_queries.extend([f'id="{v}"' for v in variants])
+
+                query = " OR ".join(variant_queries)
+                params = {
+                    "where": f"({query})",
+                    "limit": len(
+                        variant_queries
+                    ),  # Adjust limit to match number of variants
+                }
+
+                try:
+                    sub_headers = mobility_subscription_headers()
+                    response = requests.get(
+                        STOPS_API_URL,
+                        params=params,
+                        headers=sub_headers,
+                        timeout=10,
+                    )
+                    logger.debug(f"Batch API Response status: {response.status_code}")
+
+                    if response.status_code != 200:
+                        logger.warning(f"Batch API Response text: {response.text}")
+                        # Mark all stops in batch as failed
+                        for stop_id in batch:
+                            failures = cached_stops.get(stop_id, {}).get("_failures", {})
+                            if stop_id not in cached_stops:
+                                cached_stops[stop_id] = {
+                                    "name": stop_id,
+                                    "names": {"fr": stop_id, "nl": stop_id},
+                                    "coordinates": {"lat": None, "lon": None},
+                                    "_metadata": {"source": "fallback"},
+                                    "_failures": {
+                                        "count": failures.get("count", 0) + 1,
+                                        "last_failure": datetime.now().isoformat(),
+                                        "normalized_id": get_stop_id_variants(stop_id)[
+                                            -1
+                                        ],
+                                    },
+                                }
+                            else:
+                                cached_stops[stop_id]["_failures"] = {
                                     "count": failures.get("count", 0) + 1,
                                     "last_failure": datetime.now().isoformat(),
                                     "normalized_id": get_stop_id_variants(stop_id)[-1],
-                                },
-                            }
-                        else:
-                            cached_stops[stop_id]["_failures"] = {
-                                "count": failures.get("count", 0) + 1,
-                                "last_failure": datetime.now().isoformat(),
-                                "normalized_id": get_stop_id_variants(stop_id)[-1],
-                            }
-                    continue
-
-                response.raise_for_status()
-                data = response.json()
-
-                # Process results
-                found_stops = set()
-                for result in data["results"]:
-                    stop_data = result
-                    stop_id = stop_data["id"]
-
-                    # Find original stop ID that matches this result
-                    original_stop_id = None
-                    for batch_stop_id in batch:
-                        if stop_id in get_stop_id_variants(batch_stop_id):
-                            original_stop_id = batch_stop_id
-                            break
-
-                    if not original_stop_id:
-                        logger.warning(
-                            f"Could not map result stop {stop_id} back to original stop ID"
-                        )
+                                }
                         continue
 
-                    found_stops.add(original_stop_id)
+                    response.raise_for_status()
+                    data = response.json()
 
-                    # Extract coordinates
-                    gps_coords = json.loads(stop_data.get("gpscoordinates", "{}"))
-                    coordinates = {
-                        "lat": (
-                            float(gps_coords.get("latitude"))
-                            if gps_coords.get("latitude")
-                            else None
-                        ),
-                        "lon": (
-                            float(gps_coords.get("longitude"))
-                            if gps_coords.get("longitude")
-                            else None
-                        ),
-                    }
+                    # Process results
+                    found_stops = set()
+                    for result in data["results"]:
+                        stop_data = result
+                        stop_id = stop_data["id"]
 
-                    # If we have coordinates, also cache them in the GTFS coordinates cache
-                    if (
-                        coordinates["lat"] is not None
-                        and coordinates["lon"] is not None
-                    ):
-                        gtfs_coords = StopCoordinates(
-                            lat=coordinates["lat"],
-                            lon=coordinates["lon"],
-                            source="api",
-                            original_id=(
-                                stop_id if stop_id != original_stop_id else None
+                        # Find original stop ID that matches this result
+                        original_stop_id = None
+                        for batch_stop_id in batch:
+                            if stop_id in get_stop_id_variants(batch_stop_id):
+                                original_stop_id = batch_stop_id
+                                break
+
+                        if not original_stop_id:
+                            logger.warning(
+                                f"Could not map result stop {stop_id} back to original stop ID"
+                            )
+                            continue
+
+                        found_stops.add(original_stop_id)
+
+                        # Extract coordinates
+                        gps_coords = json.loads(stop_data.get("gpscoordinates", "{}"))
+                        coordinates = {
+                            "lat": (
+                                float(gps_coords.get("latitude"))
+                                if gps_coords.get("latitude")
+                                else None
                             ),
-                        )
-                        gtfs_cache = get_cached_gtfs_coordinates()
-                        gtfs_cache[original_stop_id] = gtfs_coords
-                        cache_gtfs_coordinates(gtfs_cache)
-
-                    # If we already have GTFS names, just update coordinates
-                    if original_stop_id in cached_stops:
-                        cached_stops[original_stop_id]["coordinates"] = coordinates
-                        cached_stops[original_stop_id]["_failures"] = {
-                            "count": 0,
-                            "last_failure": None,
-                            "normalized_id": stop_id,
+                            "lon": (
+                                float(gps_coords.get("longitude"))
+                                if gps_coords.get("longitude")
+                                else None
+                            ),
                         }
-                        logger.debug(
-                            f"Updated coordinates for stop {original_stop_id} from API"
-                        )
-                    else:
-                        # No GTFS data, use API data
-                        name_data = json.loads(stop_data["name"])
-                        resolved_names = resolve_stop_name(original_stop_id, name_data)
-                        cached_stops[original_stop_id] = {
-                            "name": resolved_names["fr"],
-                            "names": {
-                                "fr": resolved_names["fr"],
-                                "nl": resolved_names["nl"],
-                            },
-                            "coordinates": coordinates,
-                            "_metadata": resolved_names["_metadata"],
-                            "_failures": {
+
+                        # If we have coordinates, also cache them in the GTFS coordinates cache
+                        if (
+                            coordinates["lat"] is not None
+                            and coordinates["lon"] is not None
+                        ):
+                            gtfs_coords = StopCoordinates(
+                                lat=coordinates["lat"],
+                                lon=coordinates["lon"],
+                                source="api",
+                                original_id=(
+                                    stop_id if stop_id != original_stop_id else None
+                                ),
+                            )
+                            gtfs_cache = get_cached_gtfs_coordinates()
+                            gtfs_cache[original_stop_id] = gtfs_coords
+                            cache_gtfs_coordinates(gtfs_cache)
+
+                        # If we already have GTFS names, just update coordinates
+                        if original_stop_id in cached_stops:
+                            cached_stops[original_stop_id]["coordinates"] = coordinates
+                            cached_stops[original_stop_id]["_failures"] = {
                                 "count": 0,
                                 "last_failure": None,
                                 "normalized_id": stop_id,
-                            },
-                        }
-                        logger.debug(
-                            f"Added stop {original_stop_id} to cache with API data"
-                        )
-
-                # Mark unfound stops as failed
-                for stop_id in batch:
-                    if stop_id not in found_stops:
-                        failures = cached_stops.get(stop_id, {}).get("_failures", {})
-                        if stop_id not in cached_stops:
-                            cached_stops[stop_id] = {
-                                "name": stop_id,
-                                "names": {"fr": stop_id, "nl": stop_id},
-                                "coordinates": {"lat": None, "lon": None},
-                                "_metadata": {"source": "fallback"},
+                            }
+                            logger.debug(
+                                f"Updated coordinates for stop {original_stop_id} from API"
+                            )
+                        else:
+                            # No GTFS data, use API data
+                            name_data = json.loads(stop_data["name"])
+                            resolved_names = resolve_stop_name(
+                                original_stop_id, name_data
+                            )
+                            cached_stops[original_stop_id] = {
+                                "name": resolved_names["fr"],
+                                "names": {
+                                    "fr": resolved_names["fr"],
+                                    "nl": resolved_names["nl"],
+                                },
+                                "coordinates": coordinates,
+                                "_metadata": resolved_names["_metadata"],
                                 "_failures": {
+                                    "count": 0,
+                                    "last_failure": None,
+                                    "normalized_id": stop_id,
+                                },
+                            }
+                            logger.debug(
+                                f"Added stop {original_stop_id} to cache with API data"
+                            )
+
+                    # Mark unfound stops as failed
+                    for stop_id in batch:
+                        if stop_id not in found_stops:
+                            failures = cached_stops.get(stop_id, {}).get("_failures", {})
+                            if stop_id not in cached_stops:
+                                cached_stops[stop_id] = {
+                                    "name": stop_id,
+                                    "names": {"fr": stop_id, "nl": stop_id},
+                                    "coordinates": {"lat": None, "lon": None},
+                                    "_metadata": {"source": "fallback"},
+                                    "_failures": {
+                                        "count": failures.get("count", 0) + 1,
+                                        "last_failure": datetime.now().isoformat(),
+                                        "normalized_id": get_stop_id_variants(stop_id)[
+                                            -1
+                                        ],
+                                    },
+                                }
+                            else:
+                                cached_stops[stop_id]["_failures"] = {
                                     "count": failures.get("count", 0) + 1,
                                     "last_failure": datetime.now().isoformat(),
                                     "normalized_id": get_stop_id_variants(stop_id)[-1],
-                                },
-                            }
-                        else:
-                            cached_stops[stop_id]["_failures"] = {
-                                "count": failures.get("count", 0) + 1,
-                                "last_failure": datetime.now().isoformat(),
-                                "normalized_id": get_stop_id_variants(stop_id)[-1],
-                            }
-                        logger.warning(
-                            f"No data found for stop {stop_id}, failure count: {cached_stops[stop_id]['_failures']['count']}"
-                        )
+                                }
+                            logger.warning(
+                                f"No data found for stop {stop_id}, failure count: {cached_stops[stop_id]['_failures']['count']}"
+                            )
 
-            except Exception as e:
-                logger.error(f"Error fetching batch of stops: {e}", exc_info=True)
-                # Mark all stops in batch as failed
-                for stop_id in batch:
-                    failures = cached_stops.get(stop_id, {}).get("_failures", {})
-                    if stop_id not in cached_stops:
-                        cached_stops[stop_id] = {
-                            "name": stop_id,
-                            "names": {"fr": stop_id, "nl": stop_id},
-                            "coordinates": {"lat": None, "lon": None},
-                            "_metadata": {"source": "fallback"},
-                            "_failures": {
-                                "count": failures.get("count", 0) + 1,
-                                "last_failure": datetime.now().isoformat(),
-                                "normalized_id": get_stop_id_variants(stop_id)[-1],
-                            },
-                        }
-                    else:
-                        cached_stops[stop_id]["_failures"] = {
-                            "count": failures.get("count", 0) + 1,
-                            "last_failure": datetime.now().isoformat(),
-                            "normalized_id": get_stop_id_variants(stop_id)[-1],
-                        }
+                except (RequestsTimeout, RequestException) as e:
+                    logger.error(
+                        "STIB stops API request failed: %s", e, exc_info=True
+                    )
+                    _mark_stops_failed(batch, cached_stops)
+                except Exception as e:
+                    logger.error(f"Error fetching batch of stops: {e}", exc_info=True)
+                    _mark_stops_failed(batch, cached_stops)
 
         # Save updated cache
         save_cached_stops(cached_stops)

--- a/app/transit_providers/be/stib/get_stop_names.py
+++ b/app/transit_providers/be/stib/get_stop_names.py
@@ -19,11 +19,11 @@ from .stop_coordinates import (
     get_cached_coordinates as get_cached_gtfs_coordinates,
     cache_coordinates as cache_gtfs_coordinates,
 )
+from .mobility import mobility_subscription_headers
 
 # Get configuration
 provider_config = get_provider_config("stib")
 STOPS_API_URL = provider_config.get("STIB_STOPS_API_URL")
-API_KEY = provider_config.get("API_KEY")
 CACHE_DIR = provider_config.get("CACHE_DIR")
 STOPS_CACHE_FILE = CACHE_DIR / "stops.json"
 CACHE_DURATION = provider_config.get("CACHE_DURATION")
@@ -391,11 +391,14 @@ def get_stop_names(stop_ids, preferred_language=None):
                 "limit": len(
                     variant_queries
                 ),  # Adjust limit to match number of variants
-                "apikey": API_KEY,
             }
 
             try:
-                response = requests.get(STOPS_API_URL, params=params)
+                response = requests.get(
+                    STOPS_API_URL,
+                    params=params,
+                    headers=mobility_subscription_headers(),
+                )
                 logger.debug(f"Batch API Response status: {response.status_code}")
 
                 if response.status_code != 200:

--- a/app/transit_providers/be/stib/gtfs.py
+++ b/app/transit_providers/be/stib/gtfs.py
@@ -27,6 +27,19 @@ if GTFS_DIR is not None:
     GTFS_DIR.mkdir(parents=True, exist_ok=True)
 
 
+def _required_gtfs_filenames() -> list[str]:
+    if GTFS_USED_FILES:
+        return list(GTFS_USED_FILES)
+    return ["stops.txt"]
+
+
+def _missing_required_gtfs_files() -> list[str]:
+    req = _required_gtfs_filenames()
+    if GTFS_DIR is None:
+        return req
+    return [name for name in req if not (GTFS_DIR / name).exists()]
+
+
 def _trusted_download_netlocs() -> set[str]:
     """Hosts allowed to receive subscription headers on follow-up file downloads."""
     out = {urlparse(mobility_apim_base_url()).netloc.lower()}
@@ -39,12 +52,9 @@ def _trusted_download_netlocs() -> set[str]:
 
 
 def _headers_for_file_url(file_url: str) -> dict:
-    """Only send APIM credentials to the mobility API host (not arbitrary URLs in listings)."""
-    try:
-        parsed = urlparse(file_url)
-    except Exception:
-        return {}
-    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+    """HTTPS + trusted host only — never send the subscription key over plain HTTP."""
+    parsed = urlparse(file_url)
+    if parsed.scheme != "https" or not parsed.netloc:
         return {}
     if parsed.netloc.lower() in _trusted_download_netlocs():
         return mobility_subscription_headers()
@@ -97,8 +107,11 @@ def _download_via_ods_file_list(data: dict) -> bool:
         except Exception as e:
             logger.error(f"Error downloading file from listing: {e}")
             continue
-    downloaded = list(GTFS_DIR.glob("*.txt")) if GTFS_DIR else []
-    return bool(GTFS_DIR and (GTFS_DIR / "stops.txt").exists())
+    missing = _missing_required_gtfs_files()
+    if missing:
+        logger.error("Missing GTFS files after JSON listing download: %s", missing)
+        return False
+    return True
 
 
 def download_gtfs_data():
@@ -153,10 +166,12 @@ def download_gtfs_data():
         downloaded_files = list(GTFS_DIR.glob("*.txt"))
         logger.info(f"Extracted GTFS files: {[f.name for f in downloaded_files]}")
 
-        if not (GTFS_DIR / "stops.txt").exists():
+        missing = _missing_required_gtfs_files()
+        if missing:
             logger.error(
-                "stops.txt not found after extract. Files: "
-                f"{[f.name for f in downloaded_files]}"
+                "Missing GTFS files after extract: %s. Present: %s",
+                missing,
+                [f.name for f in downloaded_files],
             )
             return False
         return True

--- a/app/transit_providers/be/stib/gtfs.py
+++ b/app/transit_providers/be/stib/gtfs.py
@@ -3,12 +3,15 @@
 import io
 import json
 import logging
+import os
 import zipfile
+from pathlib import Path
+from urllib.parse import urlparse
 
 import niquests as requests
 from transit_providers.config import get_provider_config
 
-from .mobility import mobility_subscription_headers
+from .mobility import mobility_apim_base_url, mobility_subscription_headers
 
 logger = logging.getLogger("stib.gtfs")
 
@@ -22,6 +25,48 @@ GTFS_STATIC_FEED_URL = provider_config.get(
 GTFS_USED_FILES = provider_config.get("GTFS_USED_FILES")
 if GTFS_DIR is not None:
     GTFS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _trusted_download_netlocs() -> set[str]:
+    """Hosts allowed to receive subscription headers on follow-up file downloads."""
+    out = {urlparse(mobility_apim_base_url()).netloc.lower()}
+    extra = os.getenv("MOBILITY_TRUSTED_FILE_HOSTS", "")
+    for part in extra.split(","):
+        p = part.strip().lower()
+        if p:
+            out.add(p)
+    return out
+
+
+def _headers_for_file_url(file_url: str) -> dict:
+    """Only send APIM credentials to the mobility API host (not arbitrary URLs in listings)."""
+    try:
+        parsed = urlparse(file_url)
+    except Exception:
+        return {}
+    if parsed.scheme not in ("http", "https") or not parsed.netloc:
+        return {}
+    if parsed.netloc.lower() in _trusted_download_netlocs():
+        return mobility_subscription_headers()
+    return {}
+
+
+def _safe_extract_zip(zf: zipfile.ZipFile, dest_dir) -> None:
+    """Extract ZIP members under dest_dir only (mitigates Zip Slip)."""
+    dest_root = Path(dest_dir).resolve()
+    for member in zf.infolist():
+        name = member.filename
+        if name.endswith("/") or not name:
+            continue
+        target = (dest_root / name).resolve()
+        try:
+            target.relative_to(dest_root)
+        except ValueError:
+            logger.warning("Skipping ZIP entry outside GTFS dir: %s", name)
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with zf.open(member, "r") as src, open(target, "wb") as out_f:
+            out_f.write(src.read())
 
 
 def _download_via_ods_file_list(data: dict) -> bool:
@@ -39,7 +84,7 @@ def _download_via_ods_file_list(data: dict) -> bool:
                 logger.debug(f"Skipping unused file: {filename}")
                 continue
             logger.info(f"Downloading {filename} from {file_url}")
-            headers = mobility_subscription_headers()
+            headers = _headers_for_file_url(file_url)
             file_response = requests.get(file_url, headers=headers, timeout=120)
             if file_response.status_code != 200:
                 logger.error(
@@ -62,7 +107,8 @@ def download_gtfs_data():
         headers = mobility_subscription_headers()
         if not headers:
             logger.error(
-                "MOBILITY_API_PRIMARY_KEY (or STIB_API_KEY) is required for GTFS download"
+                "MOBILITY_API_PRIMARY_KEY, MOBILITY_API_SECONDARY_KEY, or STIB_API_KEY "
+                "is required for GTFS download"
             )
             return False
         if not GTFS_STATIC_FEED_URL or not GTFS_DIR:
@@ -101,7 +147,7 @@ def download_gtfs_data():
             )
             return False
 
-        zf.extractall(GTFS_DIR)
+        _safe_extract_zip(zf, GTFS_DIR)
         zf.close()
 
         downloaded_files = list(GTFS_DIR.glob("*.txt"))

--- a/app/transit_providers/be/stib/gtfs.py
+++ b/app/transit_providers/be/stib/gtfs.py
@@ -173,7 +173,12 @@ def ensure_gtfs_data():
     """Ensures the GTFS data is downloaded and available."""
     if not GTFS_DIR:
         return False
-    if not all((GTFS_DIR / file).exists() for file in (GTFS_USED_FILES or [])):
+    if not (GTFS_DIR / "stops.txt").exists():
+        return download_gtfs_data()
+    used = GTFS_USED_FILES or []
+    if not used:
+        return True
+    if not all((GTFS_DIR / file).exists() for file in used):
         return download_gtfs_data()
     return True
 

--- a/app/transit_providers/be/stib/gtfs.py
+++ b/app/transit_providers/be/stib/gtfs.py
@@ -1,89 +1,118 @@
-""" Download the required GTFS data from the STIB API."""
+"""Download STIB GTFS static data from the Belgian Mobility Open Data Portal."""
 
-from transit_providers.config import get_provider_config
-import niquests as requests
+import io
+import json
 import logging
+import zipfile
 
-# Get logger
+import niquests as requests
+from transit_providers.config import get_provider_config
+
+from .mobility import mobility_subscription_headers
+
 logger = logging.getLogger("stib.gtfs")
 
-# Get provider configuration
 provider_config = get_provider_config("stib")
 logger.debug(f"Provider config: {provider_config}")
 
-STIB_API_KEY = provider_config.get("API_KEY")
-GTFS_API_URL = provider_config.get("GTFS_API_URL")
 GTFS_DIR = provider_config.get("GTFS_DIR")
+GTFS_STATIC_FEED_URL = provider_config.get(
+    "GTFS_STATIC_FEED_URL"
+) or provider_config.get("GTFS_API_URL")
 GTFS_USED_FILES = provider_config.get("GTFS_USED_FILES")
-GTFS_DIR.mkdir(parents=True, exist_ok=True)
-GTFS_CACHE_DURATION = provider_config.get("GTFS_CACHE_DURATION")
-GTFS_USED_FILES = provider_config.get("GTFS_USED_FILES")
+if GTFS_DIR is not None:
+    GTFS_DIR.mkdir(parents=True, exist_ok=True)
+
+
+def _download_via_ods_file_list(data: dict) -> bool:
+    """Legacy: JSON listing of GTFS files (OpenDataSoft-style)."""
+    files = data.get("results", [])
+    for file_data in files:
+        try:
+            file_info = file_data.get("file", {})
+            filename = file_info.get("filename")
+            file_url = file_info.get("url")
+            if not filename or not file_url or not GTFS_DIR:
+                logger.error(f"Missing filename or URL in file data: {file_data}")
+                continue
+            if filename not in (GTFS_USED_FILES or []):
+                logger.debug(f"Skipping unused file: {filename}")
+                continue
+            logger.info(f"Downloading {filename} from {file_url}")
+            headers = mobility_subscription_headers()
+            file_response = requests.get(file_url, headers=headers, timeout=120)
+            if file_response.status_code != 200:
+                logger.error(
+                    f"Failed to download {filename}: {file_response.status_code}"
+                )
+                continue
+            file_path = GTFS_DIR / filename
+            file_path.write_bytes(file_response.content)
+            logger.info(f"Successfully downloaded {filename} to {file_path}")
+        except Exception as e:
+            logger.error(f"Error downloading file from listing: {e}")
+            continue
+    downloaded = list(GTFS_DIR.glob("*.txt")) if GTFS_DIR else []
+    return bool(GTFS_DIR and (GTFS_DIR / "stops.txt").exists())
 
 
 def download_gtfs_data():
-    """Connects to the GTFS API, and parses the response to get the required files."""
+    """Fetch STIB GTFS from the mobility portal (ZIP feed or legacy JSON file list)."""
     try:
-        # Ensure GTFS directory exists
-        # GTFS_DIR.mkdir(parents=True, exist_ok=True)
+        headers = mobility_subscription_headers()
+        if not headers:
+            logger.error(
+                "MOBILITY_API_PRIMARY_KEY (or STIB_API_KEY) is required for GTFS download"
+            )
+            return False
+        if not GTFS_STATIC_FEED_URL or not GTFS_DIR:
+            logger.error("GTFS_STATIC_FEED_URL or GTFS_DIR is not configured")
+            return False
 
-        # Get the GTFS files listing
-        url = f"{GTFS_API_URL}?apikey={STIB_API_KEY}"
-        response = requests.get(url)
+        logger.info("Downloading STIB GTFS from %s", GTFS_STATIC_FEED_URL)
+        response = requests.get(
+            GTFS_STATIC_FEED_URL,
+            headers=headers,
+            timeout=300,
+        )
         if response.status_code != 200:
             logger.error(
-                f"Failed to get GTFS files: {response.status_code} {response.text}"
+                "Failed to get GTFS feed: %s %s",
+                response.status_code,
+                response.text[:800],
             )
             return False
 
-        data = response.json()
-        files = data.get("results", [])
-
-        # Download each file
-        for file_data in files:
+        ctype = (response.headers.get("content-type") or "").lower()
+        if "json" in ctype or response.content[:1] == b"{":
             try:
-                file_info = file_data.get("file", {})
-                filename = file_info.get("filename")
-                file_url = file_info.get("url")
+                data = response.json()
+            except json.JSONDecodeError:
+                logger.error("GTFS endpoint returned non-JSON, non-ZIP body")
+                return False
+            return _download_via_ods_file_list(data)
 
-                if not filename or not file_url:
-                    logger.error(f"Missing filename or URL in file data: {file_data}")
-                    continue
+        try:
+            zf = zipfile.ZipFile(io.BytesIO(response.content))
+        except zipfile.BadZipFile:
+            logger.error(
+                "GTFS response was not a valid ZIP (content-type=%s)",
+                ctype or "unknown",
+            )
+            return False
 
-                if filename not in GTFS_USED_FILES:
-                    logger.debug(f"Skipping unused file: {filename}")
-                    continue
+        zf.extractall(GTFS_DIR)
+        zf.close()
 
-                logger.info(f"Downloading {filename} from {file_url}")
-                file_response = requests.get(file_url, params={"apikey": STIB_API_KEY})
-
-                if file_response.status_code != 200:
-                    logger.error(
-                        f"Failed to download {filename}: {file_response.status_code}"
-                    )
-                    continue
-
-                # Save file
-                file_path = GTFS_DIR / filename
-                file_path.write_bytes(file_response.content)
-                logger.info(f"Successfully downloaded {filename} to {file_path}")
-
-            except Exception as e:
-                logger.error(f"Error downloading {filename}: {e}")
-                import traceback
-
-                logger.error(traceback.format_exc())
-                continue
-
-        # Verify downloads
         downloaded_files = list(GTFS_DIR.glob("*.txt"))
-        logger.info(f"Downloaded files: {[f.name for f in downloaded_files]}")
+        logger.info(f"Extracted GTFS files: {[f.name for f in downloaded_files]}")
 
         if not (GTFS_DIR / "stops.txt").exists():
             logger.error(
-                f"stops.txt not found after download. Files in directory: {[f.name for f in downloaded_files]}"
+                "stops.txt not found after extract. Files: "
+                f"{[f.name for f in downloaded_files]}"
             )
             return False
-
         return True
 
     except Exception as e:
@@ -96,7 +125,9 @@ def download_gtfs_data():
 
 def ensure_gtfs_data():
     """Ensures the GTFS data is downloaded and available."""
-    if not all((GTFS_DIR / file).exists() for file in GTFS_USED_FILES):
+    if not GTFS_DIR:
+        return False
+    if not all((GTFS_DIR / file).exists() for file in (GTFS_USED_FILES or [])):
         return download_gtfs_data()
     return True
 

--- a/app/transit_providers/be/stib/mobility.py
+++ b/app/transit_providers/be/stib/mobility.py
@@ -11,8 +11,12 @@ def mobility_apim_base_url() -> str:
 
 
 def mobility_subscription_headers() -> Dict[str, str]:
-    """Primary subscription key; falls back to legacy STIB_API_KEY for local dev."""
-    key = os.getenv("MOBILITY_API_PRIMARY_KEY") or os.getenv("STIB_API_KEY")
+    """Subscription key: primary, secondary (rotation), then legacy STIB_API_KEY."""
+    key = (
+        os.getenv("MOBILITY_API_PRIMARY_KEY")
+        or os.getenv("MOBILITY_API_SECONDARY_KEY")
+        or os.getenv("STIB_API_KEY")
+    )
     if not key:
         return {}
     return {"Ocp-Apim-Subscription-Key": key}

--- a/app/transit_providers/be/stib/mobility.py
+++ b/app/transit_providers/be/stib/mobility.py
@@ -3,6 +3,8 @@
 import os
 from typing import Dict
 
+from transit_providers.config import get_provider_config
+
 _DEFAULT_APIM = "https://api-management-opendata-production.azure-api.net"
 
 
@@ -11,12 +13,19 @@ def mobility_apim_base_url() -> str:
 
 
 def mobility_subscription_headers() -> Dict[str, str]:
-    """Subscription key: primary, secondary (rotation), then legacy STIB_API_KEY."""
+    """Subscription key from env, then merged STIB provider config (e.g. local.py)."""
     key = (
         os.getenv("MOBILITY_API_PRIMARY_KEY")
         or os.getenv("MOBILITY_API_SECONDARY_KEY")
         or os.getenv("STIB_API_KEY")
     )
+    if not key:
+        pc = get_provider_config("stib")
+        key = (
+            (pc.get("MOBILITY_API_PRIMARY_KEY") or "")
+            or (pc.get("MOBILITY_API_SECONDARY_KEY") or "")
+            or (pc.get("API_KEY") or "")
+        )
     if not key:
         return {}
     return {"Ocp-Apim-Subscription-Key": key}

--- a/app/transit_providers/be/stib/mobility.py
+++ b/app/transit_providers/be/stib/mobility.py
@@ -1,0 +1,25 @@
+"""Belgian Mobility Open Data Portal (Azure API Management) helpers."""
+
+import os
+from typing import Dict
+
+_DEFAULT_APIM = "https://api-management-opendata-production.azure-api.net"
+
+
+def mobility_apim_base_url() -> str:
+    return os.getenv("MOBILITY_APIM_BASE_URL", _DEFAULT_APIM).rstrip("/")
+
+
+def mobility_subscription_headers() -> Dict[str, str]:
+    """Primary subscription key; falls back to legacy STIB_API_KEY for local dev."""
+    key = os.getenv("MOBILITY_API_PRIMARY_KEY") or os.getenv("STIB_API_KEY")
+    if not key:
+        return {}
+    return {"Ocp-Apim-Subscription-Key": key}
+
+
+def mobility_url(path: str) -> str:
+    """Join base URL with an absolute path (e.g. /api/datasets/stibmivb/rt/WaitingTimes)."""
+    if not path.startswith("/"):
+        path = "/" + path
+    return f"{mobility_apim_base_url()}{path}"

--- a/app/transit_providers/be/stib/routes.py
+++ b/app/transit_providers/be/stib/routes.py
@@ -254,14 +254,16 @@ async def get_stops_for_line(line: str) -> Dict[str, List[Dict]]:
     if not STIB_STOPS_BY_LINE_API_URL:
         logger.error("STIB_STOPS_BY_LINE_API_URL is not configured")
         return cached_stops or {"City": [], "Suburb": []}
+    sub_headers = mobility_subscription_headers()
+    if not sub_headers.get("Ocp-Apim-Subscription-Key"):
+        logger.error("Mobility subscription key is not configured")
+        return cached_stops or {"City": [], "Suburb": []}
     url = STIB_STOPS_BY_LINE_API_URL
     params = {"where": f"lineid={line}", "limit": 20}
 
     try:
         async with await get_client() as client:
-            response = await client.get(
-                url, params=params, headers=mobility_subscription_headers()
-            )
+            response = await client.get(url, params=params, headers=sub_headers)
             # Update rate limits from response headers
             rate_limiter.update_from_headers(response.headers)
 
@@ -346,14 +348,16 @@ async def get_route_data(line: str) -> Dict[str, List[Dict]]:
     if not STIB_STOPS_BY_LINE_API_URL:
         logger.error("STIB_STOPS_BY_LINE_API_URL is not configured")
         return {}
+    sub_headers = mobility_subscription_headers()
+    if not sub_headers.get("Ocp-Apim-Subscription-Key"):
+        logger.error("Mobility subscription key is not configured")
+        return {}
     url = STIB_STOPS_BY_LINE_API_URL
     params = {"where": f"lineid={line}", "limit": 20}
 
     try:
         async with await get_client() as client:
-            response = await client.get(
-                url, params=params, headers=mobility_subscription_headers()
-            )
+            response = await client.get(url, params=params, headers=sub_headers)
             # Update rate limits from response headers
             rate_limiter.update_from_headers(response.headers)
 

--- a/app/transit_providers/be/stib/routes.py
+++ b/app/transit_providers/be/stib/routes.py
@@ -6,20 +6,26 @@ from datetime import datetime, timedelta
 import asyncio
 
 import logging
-from app.utils import RateLimiter, get_client
-from app.config import get_config
+from utils import RateLimiter, get_client
+from config import get_config
+from transit_providers.config import get_provider_config
+
+from .mobility import mobility_subscription_headers
 
 # Setup logging using configuration
 
 # Get logger
 logger = logging.getLogger("stib.routes")
 
+_provider = get_provider_config("stib")
+STIB_SHAPEFILES_API_URL = _provider.get("STIB_SHAPEFILES_API_URL")
+STIB_STOPS_BY_LINE_API_URL = _provider.get("STIB_STOPS_BY_LINE_API_URL")
+
 # Create cache directories for shapefiles and stops
 SHAPES_CACHE_DIR = get_config("CACHE_DIR") / "shapes"
 STOPS_CACHE_DIR = get_config("CACHE_DIR") / "stops"
 
 CACHE_DURATION = get_config("CACHE_DURATION")
-API_KEY = get_config("STIB_API_KEY")
 
 RATE_LIMIT_DELAY = get_config("RATE_LIMIT_DELAY")
 
@@ -112,17 +118,21 @@ async def get_route_shape(line: str) -> List[Dict]:
         formatted_line = f"{int(line):03}b"  # For bus lines
         formatted_line_fallback = f"{int(line):03}t"  # For tram lines
         formatted_line_fallback_2 = f"{int(line):03}m"  # For metro lines
-        url = "https://stibmivb.opendatasoft.com/api/explore/v2.1/catalog/datasets/shapefiles-production/records"
+        if not STIB_SHAPEFILES_API_URL:
+            logger.error("STIB_SHAPEFILES_API_URL is not configured")
+            return cached_variants or []
+        url = STIB_SHAPEFILES_API_URL
         params = {
             "where": f'ligne="{formatted_line}" or ligne="{formatted_line_fallback}" or ligne="{formatted_line_fallback_2}"',
             "limit": 20,
-            "apikey": API_KEY,
         }
 
         logger.debug(f"Making API request for line {line}")
 
         async with await get_client() as client:
-            response = await client.get(url, params=params)
+            response = await client.get(
+                url, params=params, headers=mobility_subscription_headers()
+            )
             # Update rate limits from response headers
             rate_limiter.update_from_headers(response.headers)
 
@@ -239,12 +249,17 @@ async def get_stops_for_line(line: str) -> Dict[str, List[Dict]]:
     if not should_refresh:
         return cached_stops
 
-    url = "https://stibmivb.opendatasoft.com/api/explore/v2.1/catalog/datasets/stops-by-line-production/records"
-    params = {"where": f"lineid={line}", "limit": 20, "apikey": API_KEY}
+    if not STIB_STOPS_BY_LINE_API_URL:
+        logger.error("STIB_STOPS_BY_LINE_API_URL is not configured")
+        return cached_stops or {"City": [], "Suburb": []}
+    url = STIB_STOPS_BY_LINE_API_URL
+    params = {"where": f"lineid={line}", "limit": 20}
 
     try:
         async with await get_client() as client:
-            response = await client.get(url, params=params)
+            response = await client.get(
+                url, params=params, headers=mobility_subscription_headers()
+            )
             # Update rate limits from response headers
             rate_limiter.update_from_headers(response.headers)
 
@@ -326,12 +341,17 @@ def match_stops_to_variants(shapes: Dict, stops_by_direction: Dict) -> Dict:
 
 async def get_route_data(line: str) -> Dict[str, List[Dict]]:
     """Get route data for a line, including stops and destinations"""
-    url = "https://stibmivb.opendatasoft.com/api/explore/v2.1/catalog/datasets/stops-by-line-production/records"
-    params = {"where": f"lineid={line}", "limit": 20, "apikey": API_KEY}
+    if not STIB_STOPS_BY_LINE_API_URL:
+        logger.error("STIB_STOPS_BY_LINE_API_URL is not configured")
+        return {}
+    url = STIB_STOPS_BY_LINE_API_URL
+    params = {"where": f"lineid={line}", "limit": 20}
 
     try:
         async with await get_client() as client:
-            response = await client.get(url, params=params)
+            response = await client.get(
+                url, params=params, headers=mobility_subscription_headers()
+            )
             # Update rate limits from response headers
             rate_limiter.update_from_headers(response.headers)
 

--- a/app/transit_providers/be/stib/routes.py
+++ b/app/transit_providers/be/stib/routes.py
@@ -18,7 +18,9 @@ from .mobility import mobility_subscription_headers
 logger = logging.getLogger("stib.routes")
 
 _provider = get_provider_config("stib")
-STIB_SHAPEFILES_API_URL = _provider.get("STIB_SHAPEFILES_API_URL")
+STIB_SHAPE_FILES_API_URL = _provider.get("STIB_SHAPE_FILES_API_URL") or _provider.get(
+    "STIB_SHAPEFILES_API_URL"
+)
 STIB_STOPS_BY_LINE_API_URL = _provider.get("STIB_STOPS_BY_LINE_API_URL")
 
 # Create cache directories for shapefiles and stops
@@ -118,10 +120,10 @@ async def get_route_shape(line: str) -> List[Dict]:
         formatted_line = f"{int(line):03}b"  # For bus lines
         formatted_line_fallback = f"{int(line):03}t"  # For tram lines
         formatted_line_fallback_2 = f"{int(line):03}m"  # For metro lines
-        if not STIB_SHAPEFILES_API_URL:
-            logger.error("STIB_SHAPEFILES_API_URL is not configured")
+        if not STIB_SHAPE_FILES_API_URL:
+            logger.error("STIB_SHAPE_FILES_API_URL is not configured")
             return cached_variants or []
-        url = STIB_SHAPEFILES_API_URL
+        url = STIB_SHAPE_FILES_API_URL
         params = {
             "where": f'ligne="{formatted_line}" or ligne="{formatted_line_fallback}" or ligne="{formatted_line_fallback_2}"',
             "limit": 20,

--- a/app/transit_providers/be/stib/test_mobility.py
+++ b/app/transit_providers/be/stib/test_mobility.py
@@ -7,9 +7,11 @@ from .mobility import mobility_apim_base_url, mobility_url
 
 def test_mobility_url_joins_base(monkeypatch):
     monkeypatch.delenv("MOBILITY_APIM_BASE_URL", raising=False)
-    assert mobility_apim_base_url().endswith("azure-api.net")
-    assert mobility_url("/api/datasets/stibmivb/rt/WaitingTimes").endswith(
-        "/api/datasets/stibmivb/rt/WaitingTimes"
+    expected_base = "https://api-management-opendata-production.azure-api.net"
+    assert mobility_apim_base_url() == expected_base
+    assert (
+        mobility_url("/api/datasets/stibmivb/rt/WaitingTimes")
+        == f"{expected_base}/api/datasets/stibmivb/rt/WaitingTimes"
     )
 
 

--- a/app/transit_providers/be/stib/test_mobility.py
+++ b/app/transit_providers/be/stib/test_mobility.py
@@ -1,18 +1,23 @@
 """Unit tests for Belgian Mobility APIM URL helpers (no network)."""
 
+from urllib.parse import urlparse
+
 import pytest
 
-from .mobility import mobility_apim_base_url, mobility_url
+from . import mobility as mobility_mod
+from .mobility import mobility_apim_base_url, mobility_subscription_headers, mobility_url
 
 
 def test_mobility_url_joins_base(monkeypatch):
     monkeypatch.delenv("MOBILITY_APIM_BASE_URL", raising=False)
     expected_base = "https://api-management-opendata-production.azure-api.net"
     assert mobility_apim_base_url() == expected_base
-    assert (
-        mobility_url("/api/datasets/stibmivb/rt/WaitingTimes")
-        == f"{expected_base}/api/datasets/stibmivb/rt/WaitingTimes"
-    )
+    waiting = mobility_url("/api/datasets/stibmivb/rt/WaitingTimes")
+    assert waiting == f"{expected_base}/api/datasets/stibmivb/rt/WaitingTimes"
+    parsed = urlparse(waiting)
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "api-management-opendata-production.azure-api.net"
+    assert parsed.path == "/api/datasets/stibmivb/rt/WaitingTimes"
 
 
 def test_mobility_apim_base_override(monkeypatch):
@@ -24,3 +29,18 @@ def test_mobility_apim_base_override(monkeypatch):
 def test_mobility_url_accepts_path_without_leading_slash(monkeypatch):
     monkeypatch.setenv("MOBILITY_APIM_BASE_URL", "https://example.com")
     assert mobility_url("api/v") == "https://example.com/api/v"
+
+
+def test_mobility_subscription_headers_from_provider_config(monkeypatch):
+    monkeypatch.delenv("MOBILITY_API_PRIMARY_KEY", raising=False)
+    monkeypatch.delenv("MOBILITY_API_SECONDARY_KEY", raising=False)
+    monkeypatch.delenv("STIB_API_KEY", raising=False)
+
+    def fake_pc(name: str):
+        assert name == "stib"
+        return {"MOBILITY_API_PRIMARY_KEY": "k-from-provider-config"}
+
+    monkeypatch.setattr(mobility_mod, "get_provider_config", fake_pc)
+    assert mobility_subscription_headers() == {
+        "Ocp-Apim-Subscription-Key": "k-from-provider-config",
+    }

--- a/app/transit_providers/be/stib/test_mobility.py
+++ b/app/transit_providers/be/stib/test_mobility.py
@@ -1,0 +1,24 @@
+"""Unit tests for Belgian Mobility APIM URL helpers (no network)."""
+
+import pytest
+
+from .mobility import mobility_apim_base_url, mobility_url
+
+
+def test_mobility_url_joins_base(monkeypatch):
+    monkeypatch.delenv("MOBILITY_APIM_BASE_URL", raising=False)
+    assert mobility_apim_base_url().endswith("azure-api.net")
+    assert mobility_url("/api/datasets/stibmivb/rt/WaitingTimes").endswith(
+        "/api/datasets/stibmivb/rt/WaitingTimes"
+    )
+
+
+def test_mobility_apim_base_override(monkeypatch):
+    monkeypatch.setenv("MOBILITY_APIM_BASE_URL", "https://example.com/")
+    assert mobility_apim_base_url() == "https://example.com"
+    assert mobility_url("/x") == "https://example.com/x"
+
+
+def test_mobility_url_accepts_path_without_leading_slash(monkeypatch):
+    monkeypatch.setenv("MOBILITY_APIM_BASE_URL", "https://example.com")
+    assert mobility_url("api/v") == "https://example.com/api/v"

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,10 @@
+"""Pytest: PROJECT_ROOT must match runtime (see start.py / app layout)."""
+
+import os
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parent
+_APP = _REPO / "app"
+os.environ.setdefault("PROJECT_ROOT", str(_APP))
+# Logging handlers in config/default.py expect this directory
+(_APP / "logs").mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

Migrates STIB outbound API usage from legacy OpenDataSoft-style hosts and `apikey` query parameters to the Belgian Mobility Open Data portal on Azure API Management.

- Uses `Ocp-Apim-Subscription-Key` from `MOBILITY_API_PRIMARY_KEY` (with `STIB_API_KEY` fallback where applicable).
- Updates dataset and GTFS static feed URLs to the new `/api/datasets/stibmivb/...` paths.
- Adds `mobility.py` helpers and unit tests; repo/app `conftest.py` sets `PROJECT_ROOT` and ensures `app/logs` exists for pytest.

## Env

See `.env.example` for `MOBILITY_API_PRIMARY_KEY`, `MOBILITY_API_SECONDARY_KEY`, and optional `MOBILITY_APIM_BASE_URL`.

## Testing

`PYTHONPATH=app python -m pytest app/transit_providers/be/stib/test_mobility.py`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Integrated Belgian Mobility Open Data access for STIB with subscription-key authentication and support for static GTFS feeds for improved route/stop data.

* **Bug Fixes**
  * Better handling when API/configuration is missing, improved rate-limit error details, and safer GTFS extraction to avoid file-security issues.

* **Tests**
  * Added unit tests for Mobility API URL and header helpers.

* **Documentation**
  * Added example environment placeholders for Mobility API credentials and optional base URL.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->