### PR TITLE
Migrate SNCB to Belgian Mobility APIM

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,7 +12,13 @@ DELIJN_GTFS_STATIC_API_KEY=your-delijn-gtfs-static-key-here
 DELIJN_GTFS_REALTIME_API_KEY=your-delijn-gtfs-realtime-key-here
 BKK_API_KEY=your-bkk-api-key-here
 MOBILITY_API_REFRESH_TOKEN=your-mobility-api-refresh-token-here
-SNCB_GTFS_REALTIME_API_URL=your-sncb-gtfs-realtime-api-url-here
+
+# SNCB/NMBS uses Belgian Mobility APIM by default for static GTFS and realtime trip updates.
+# Optional overrides:
+# SNCB_GTFS_STATIC_URL=https://api-management-opendata-production.azure-api.net/api/gtfs/feed/nmbssncb/static
+# SNCB_BELGIAN_MOBILITY_TRIP_UPDATES_URL=https://api-management-opendata-production.azure-api.net/api/gtfs/feed/nmbssncb/rt/trip-update
+# Legacy/deprecated realtime source, only used with SNCB_REALTIME_SOURCE=legacy:
+# SNCB_LEGACY_GTFS_REALTIME_API_URL=your-legacy-sncb-gtfs-realtime-url
 
 # Schedule Explorer Configuration
 # For local development:

--- a/.env.example
+++ b/.env.example
@@ -14,6 +14,7 @@ BKK_API_KEY=your-bkk-api-key-here
 MOBILITY_API_REFRESH_TOKEN=your-mobility-api-refresh-token-here
 
 # SNCB/NMBS uses Belgian Mobility APIM by default for static GTFS and realtime trip updates.
+# Requires MOBILITY_API_PRIMARY_KEY or MOBILITY_API_SECONDARY_KEY above for APIM authentication.
 # Optional overrides:
 # SNCB_GTFS_STATIC_URL=https://api-management-opendata-production.azure-api.net/api/gtfs/feed/nmbssncb/static
 # SNCB_BELGIAN_MOBILITY_TRIP_UPDATES_URL=https://api-management-opendata-production.azure-api.net/api/gtfs/feed/nmbssncb/rt/trip-update

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 **Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
 
 - [Changelog](#changelog)
+  - [Unreleased](#unreleased)
   - [v0.2.5 (2026-05-02)](#v025-2026-05-02)
   - [v0.2.1 (2025-01-09)](#v021-2025-01-09)
   - [v0.2.0 (2025-01-03)](#v020-2025-01-03)
@@ -13,6 +14,15 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 # Changelog
+
+## Unreleased
+
+**SNCB/NMBS — Belgian Mobility Open Data (Azure APIM)**
+
+- Use Belgian Mobility APIM as the primary SNCB static GTFS and realtime trip-update source.
+- Normalize Belgian Mobility SNCB/NMBS GTFS IDs to the existing provider ID shape so current stop and line configuration remains compatible.
+- Keep Mobility Database / GTFS.be as the static GTFS fallback; remove GTFS.be realtime as a fallback because its `tripUpdates.pb` mirror is not reliably live.
+- Document the new `MOBILITY_API_PRIMARY_KEY` / `MOBILITY_API_SECONDARY_KEY` requirement and the legacy SNCB realtime opt-in.
 
 ## [v0.2.5](https://github.com/bdamokos/brussels_transit/tree/v0.2.5) (2026-05-02)
 

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -147,12 +147,14 @@ The servers will be available at:
 Create a `.env` file with the following variables (depending on your API choice):
 ```env
 # Real-time Transit Display APIs
+MOBILITY_API_PRIMARY_KEY=your_mobility_primary_subscription_key
+MOBILITY_API_SECONDARY_KEY=your_mobility_secondary_subscription_key
 STIB_API_KEY=your_stib_api_key
 DELIJN_API_KEY=your_delijn_api_key
 DELIJN_GTFS_STATIC_API_KEY=your_delijn_gtfs_static_key
 DELIJN_GTFS_REALTIME_API_KEY=your_delijn_gtfs_realtime_key
 BKK_API_KEY=your_bkk_api_key
-MOBILITY_API_REFRESH_TOKEN=your_mobility_api_refresh_token # optional
+MOBILITY_API_REFRESH_TOKEN=your_mobility_api_refresh_token # optional static GTFS fallback
 
 # Port Configuration
 PORT=5001  # For Real-time Transit Display
@@ -242,4 +244,4 @@ docker compose -f <config-file> logs -f
 
 # Stop services
 docker compose -f <config-file> down
-``` 
+```

--- a/app/config/local.py.example
+++ b/app/config/local.py.example
@@ -9,6 +9,8 @@ If you want to override any settings, do so in local.py.
 # API Keys
 MOBILITY_API_PRIMARY_KEY = "your-belgian-mobility-primary-subscription-key"
 MOBILITY_API_SECONDARY_KEY = "your-belgian-mobility-secondary-subscription-key"
+# Optional: static GTFS fallback
+# MOBILITY_API_REFRESH_TOKEN = "your-mobility-database-refresh-token"
 STIB_API_KEY = "your-stib-api-key"
 DELIJN_API_KEY = "your-delijn-api-key"
 DELIJN_GTFS_STATIC_API_KEY = "your-delijn-gtfs-static-key"

--- a/app/config/local.py.example
+++ b/app/config/local.py.example
@@ -7,6 +7,8 @@ If you want to override any settings, do so in local.py.
 """
 
 # API Keys
+MOBILITY_API_PRIMARY_KEY = "your-belgian-mobility-primary-subscription-key"
+MOBILITY_API_SECONDARY_KEY = "your-belgian-mobility-secondary-subscription-key"
 STIB_API_KEY = "your-stib-api-key"
 DELIJN_API_KEY = "your-delijn-api-key"
 DELIJN_GTFS_STATIC_API_KEY = "your-delijn-gtfs-static-key"

--- a/app/transit_providers/be/mobility.py
+++ b/app/transit_providers/be/mobility.py
@@ -44,9 +44,9 @@ def mobility_subscription_headers(
                 break
 
     if not key and provider_name:
-        pc = get_provider_config(provider_name)
-        key = (pc.get("MOBILITY_API_PRIMARY_KEY") or "") or (
-            pc.get("MOBILITY_API_SECONDARY_KEY") or ""
+        pc = get_provider_config(provider_name) or {}
+        key = pc.get("MOBILITY_API_PRIMARY_KEY") or pc.get(
+            "MOBILITY_API_SECONDARY_KEY"
         )
         if not key:
             for config_key in legacy_config_keys:

--- a/app/transit_providers/be/mobility.py
+++ b/app/transit_providers/be/mobility.py
@@ -1,0 +1,59 @@
+"""Belgian Mobility Open Data Portal (Azure API Management) helpers."""
+
+import os
+from typing import Dict, Iterable
+
+from config import get_config
+from transit_providers.config import get_provider_config
+
+_DEFAULT_APIM = "https://api-management-opendata-production.azure-api.net"
+
+
+def mobility_apim_base_url() -> str:
+    return (
+        os.getenv("MOBILITY_APIM_BASE_URL")
+        or get_config("MOBILITY_APIM_BASE_URL")
+        or _DEFAULT_APIM
+    ).rstrip("/")
+
+
+def mobility_url(path: str) -> str:
+    """Join the APIM base URL with an absolute path."""
+    if not path.startswith("/"):
+        path = "/" + path
+    return f"{mobility_apim_base_url()}{path}"
+
+
+def mobility_subscription_headers(
+    provider_name: str | None = None,
+    legacy_env_keys: Iterable[str] = (),
+    legacy_config_keys: Iterable[str] = (),
+) -> Dict[str, str]:
+    """Return the Belgian Mobility subscription header, if a key is configured."""
+    key = (
+        os.getenv("MOBILITY_API_PRIMARY_KEY")
+        or os.getenv("MOBILITY_API_SECONDARY_KEY")
+        or get_config("MOBILITY_API_PRIMARY_KEY")
+        or get_config("MOBILITY_API_SECONDARY_KEY")
+    )
+
+    if not key:
+        for env_key in legacy_env_keys:
+            key = os.getenv(env_key)
+            if key:
+                break
+
+    if not key and provider_name:
+        pc = get_provider_config(provider_name)
+        key = (pc.get("MOBILITY_API_PRIMARY_KEY") or "") or (
+            pc.get("MOBILITY_API_SECONDARY_KEY") or ""
+        )
+        if not key:
+            for config_key in legacy_config_keys:
+                key = pc.get(config_key)
+                if key:
+                    break
+
+    if not key:
+        return {}
+    return {"bmc-partner-key": key}

--- a/app/transit_providers/be/sncb/__init__.py
+++ b/app/transit_providers/be/sncb/__init__.py
@@ -26,7 +26,13 @@ from .api import (
 
 provider_config = get_provider_config("sncb")
 logger.info("=== SNCB CONFIG DEBUG ===")
-logger.info(f"Raw config: {provider_config}")
+logger.info(
+    "Raw config: %s",
+    {
+        key: ("<redacted>" if "KEY" in key or "TOKEN" in key or "URL" in key else value)
+        for key, value in provider_config.items()
+    },
+)
 logger.info("=== END SNCB CONFIG DEBUG ===")
 
 GTFS_DIR = provider_config.get("GTFS_DIR")

--- a/app/transit_providers/be/sncb/__init__.py
+++ b/app/transit_providers/be/sncb/__init__.py
@@ -24,12 +24,36 @@ from .api import (
     _ensure_caches_initialized,
 )
 
+
+def _redact_config_value(key: str, value: Any) -> Any:
+    upper_key = key.upper()
+    if "KEY" in upper_key or "TOKEN" in upper_key:
+        return "<redacted>"
+    if upper_key == "LEGACY_REALTIME_URL":
+        return "<redacted>"
+    if "URL" in upper_key and isinstance(value, str):
+        sensitive_markers = (
+            "api_key",
+            "apikey",
+            "access_token",
+            "sncb-opendata.hafas.de/gtfs/realtime/",
+            "subscription-key",
+            "password",
+            "signature",
+            "token=",
+            "key=",
+        )
+        if any(marker in value.lower() for marker in sensitive_markers):
+            return "<redacted>"
+    return value
+
+
 provider_config = get_provider_config("sncb")
 logger.info("=== SNCB CONFIG DEBUG ===")
 logger.info(
     "Raw config: %s",
     {
-        key: ("<redacted>" if "KEY" in key or "TOKEN" in key or "URL" in key else value)
+        key: _redact_config_value(key, value)
         for key, value in provider_config.items()
     },
 )

--- a/app/transit_providers/be/sncb/api.py
+++ b/app/transit_providers/be/sncb/api.py
@@ -1,6 +1,7 @@
 """SNCB (Belgium) transit provider API implementation"""
 
 import os
+import csv
 import io
 import json
 import shutil
@@ -168,16 +169,11 @@ def _load_stop_times_cache() -> None:
 
         new_cache = {}
         with open(stop_times_file, "r", encoding="utf-8") as f:
-            header = next(f).strip().split(",")
-            trip_id_index = header.index("trip_id")
-            stop_id_index = header.index("stop_id")
-            stop_sequence_index = header.index("stop_sequence")
-
-            for line in f:
-                fields = line.strip().split(",")
-                trip_id = strip_sncb_id_prefix(fields[trip_id_index].strip('"'))
+            reader = csv.DictReader(f)
+            for row in reader:
+                trip_id = strip_sncb_id_prefix(row["trip_id"])
                 stop_id = normalize_sncb_stop_id(
-                    fields[stop_id_index].strip('"'), collapse_platform=True
+                    row["stop_id"], collapse_platform=True
                 )
 
                 if trip_id not in new_cache:
@@ -186,7 +182,7 @@ def _load_stop_times_cache() -> None:
                 new_cache[trip_id].append(
                     {
                         "stop_id": stop_id,
-                        "stop_sequence": int(fields[stop_sequence_index]),
+                        "stop_sequence": int(row["stop_sequence"]),
                     }
                 )
 
@@ -220,42 +216,38 @@ def _load_trips_cache() -> None:
 
         new_cache = {}
         with open(trips_file, "r", encoding="utf-8") as f:
-            header = next(f).strip().split(",")
-            try:
-                trip_id_index = header.index("trip_id")
-                trip_headsign_index = header.index("trip_headsign")
-                route_id_index = header.index("route_id")
-            except ValueError as e:
-                logger.error(f"Required column not found in trips.txt: {e}")
+            reader = csv.DictReader(f)
+            required_columns = {"trip_id", "trip_headsign", "route_id"}
+            if not reader.fieldnames or not required_columns.issubset(
+                reader.fieldnames
+            ):
+                missing = required_columns.difference(reader.fieldnames or [])
+                logger.error("Required columns not found in trips.txt: %s", missing)
                 return
 
-            for line in f:
-                fields = line.strip().split(",")
-                if len(fields) > max(
-                    trip_id_index, trip_headsign_index, route_id_index
-                ):
-                    route_id = strip_sncb_id_prefix(fields[route_id_index].strip('"'))
-                    trip_id = strip_sncb_id_prefix(fields[trip_id_index].strip('"'))
-                    headsign = fields[trip_headsign_index].strip('"')
+            for row in reader:
+                route_id = strip_sncb_id_prefix(row["route_id"])
+                trip_id = strip_sncb_id_prefix(row["trip_id"])
+                headsign = row["trip_headsign"]
 
-                    trip_data = {
-                        "headsign": headsign,
-                        "route_id": route_id,
-                    }
+                trip_data = {
+                    "headsign": headsign,
+                    "route_id": route_id,
+                }
 
-                    # Always cache monitored lines
-                    if not monitored_lines or route_id in monitored_lines:
-                        new_cache[trip_id] = trip_data
-                    # For non-monitored lines, use LRU cache
-                    elif trip_id in _trips_lru_cache:
-                        new_cache[trip_id] = _trips_lru_cache[trip_id]
-                    else:
-                        # Add to LRU cache if there's space or remove oldest entry
-                        if len(_trips_lru_cache) >= _trips_lru_cache_max_size:
-                            # Remove oldest entry (first key in dict)
-                            _trips_lru_cache.pop(next(iter(_trips_lru_cache)))
-                        _trips_lru_cache[trip_id] = trip_data
-                        new_cache[trip_id] = trip_data
+                # Always cache monitored lines
+                if not monitored_lines or route_id in monitored_lines:
+                    new_cache[trip_id] = trip_data
+                # For non-monitored lines, use LRU cache
+                elif trip_id in _trips_lru_cache:
+                    new_cache[trip_id] = _trips_lru_cache[trip_id]
+                else:
+                    # Add to LRU cache if there's space or remove oldest entry
+                    if len(_trips_lru_cache) >= _trips_lru_cache_max_size:
+                        # Remove oldest entry (first key in dict)
+                        _trips_lru_cache.pop(next(iter(_trips_lru_cache)))
+                    _trips_lru_cache[trip_id] = trip_data
+                    new_cache[trip_id] = trip_data
 
         _trips_cache = new_cache
         _trips_cache_update = datetime.now(timezone.utc)
@@ -363,6 +355,7 @@ class GTFSManager:
         )
         self.current_gtfs_path: Optional[Path] = None
         self.mobility_api: Optional[MobilityAPI] = None
+        self._lock: Optional[asyncio.Lock] = None
         logger.info(f"Initializing GTFSManager with directory: {self.gtfs_dir}")
 
         # Create GTFS directory if it doesn't exist
@@ -388,7 +381,7 @@ class GTFSManager:
         if not self.apim_metadata_file.exists():
             return False
         try:
-            metadata = json.loads(self.apim_metadata_file.read_text())
+            metadata = json.loads(self.apim_metadata_file.read_text(encoding="utf-8"))
             downloaded_at = datetime.fromisoformat(metadata["downloaded_at"])
             if downloaded_at.tzinfo is None:
                 downloaded_at = downloaded_at.replace(tzinfo=timezone.utc)
@@ -444,7 +437,6 @@ class GTFSManager:
             if self.apim_gtfs_dir.exists():
                 shutil.rmtree(self.apim_gtfs_dir)
             tmp_dir.rename(self.apim_gtfs_dir)
-            self.apim_gtfs_dir.mkdir(parents=True, exist_ok=True)
 
             metadata = {
                 "downloaded_at": datetime.now(timezone.utc).isoformat(),
@@ -454,7 +446,9 @@ class GTFSManager:
                 "etag": response.headers.get("etag"),
             }
             self.apim_metadata_file.parent.mkdir(parents=True, exist_ok=True)
-            self.apim_metadata_file.write_text(json.dumps(metadata, indent=2))
+            self.apim_metadata_file.write_text(
+                json.dumps(metadata, indent=2), encoding="utf-8"
+            )
 
             logger.info(
                 "Downloaded SNCB Belgian Mobility GTFS to %s (%.2f MB)",
@@ -471,7 +465,12 @@ class GTFSManager:
     async def _ensure_apim_gtfs_data(self) -> Optional[Path]:
         if self._apim_cache_is_valid():
             return self.apim_gtfs_dir
-        return await self._download_apim_static_gtfs()
+        if self._lock is None:
+            self._lock = asyncio.Lock()
+        async with self._lock:
+            if self._apim_cache_is_valid():
+                return self.apim_gtfs_dir
+            return await self._download_apim_static_gtfs()
 
     def _is_dataset_expired(self, dataset) -> bool:
         """Check if dataset needs updating"""
@@ -647,35 +646,15 @@ def _load_routes_cache() -> None:
 
         new_cache = {}
         with open(routes_file, "r", encoding="utf-8") as f:
-            header = next(f).strip().split(",")
-            route_id_index = header.index("route_id")
-            route_short_name_index = header.index("route_short_name")
-            route_desc_index = (
-                header.index("route_desc") if "route_desc" in header else -1
-            )
-            route_long_name_index = (
-                header.index("route_long_name") if "route_long_name" in header else -1
-            )
-            route_type_index = (
-                header.index("route_type") if "route_type" in header else -1
-            )
-
-            for line in f:
-                fields = line.strip().split(",")
-                route_id = strip_sncb_id_prefix(fields[route_id_index])
+            reader = csv.DictReader(f)
+            for row in reader:
+                route_id = strip_sncb_id_prefix(row["route_id"])
+                route_type = row.get("route_type")
                 new_cache[route_id] = {
-                    "route_short_name": fields[route_short_name_index],
-                    "route_desc": (
-                        fields[route_desc_index] if route_desc_index >= 0 else None
-                    ),
-                    "route_long_name": (
-                        fields[route_long_name_index]
-                        if route_long_name_index >= 0
-                        else None
-                    ),
-                    "route_type": (
-                        int(fields[route_type_index]) if route_type_index >= 0 else None
-                    ),
+                    "route_short_name": row["route_short_name"],
+                    "route_desc": row.get("route_desc"),
+                    "route_long_name": row.get("route_long_name"),
+                    "route_type": int(route_type) if route_type else None,
                 }
 
         _routes_cache = new_cache
@@ -860,10 +839,11 @@ def _normalize_realtime_feed_ids(feed: gtfs_realtime_pb2.FeedMessage) -> None:
 
         if entity.HasField("vehicle"):
             vehicle = entity.vehicle
-            if vehicle.trip.trip_id:
-                vehicle.trip.trip_id = strip_sncb_id_prefix(vehicle.trip.trip_id)
-            if vehicle.trip.route_id:
-                vehicle.trip.route_id = strip_sncb_id_prefix(vehicle.trip.route_id)
+            if vehicle.HasField("trip"):
+                if vehicle.trip.trip_id:
+                    vehicle.trip.trip_id = strip_sncb_id_prefix(vehicle.trip.trip_id)
+                if vehicle.trip.route_id:
+                    vehicle.trip.route_id = strip_sncb_id_prefix(vehicle.trip.route_id)
             if vehicle.stop_id:
                 vehicle.stop_id = normalize_sncb_stop_id(
                     vehicle.stop_id, collapse_platform=True
@@ -893,6 +873,8 @@ async def _fetch_trip_updates_feed(
             "MOBILITY_API_PRIMARY_KEY or MOBILITY_API_SECONDARY_KEY is required "
             "for SNCB Belgian Mobility realtime"
         )
+    if not APIM_TRIP_UPDATES_URL:
+        raise RuntimeError("SNCB APIM_TRIP_UPDATES_URL is not configured")
     response = await client.get(APIM_TRIP_UPDATES_URL, headers=headers)
     response.raise_for_status()
     feed = gtfs_realtime_pb2.FeedMessage()
@@ -1355,17 +1337,9 @@ def _get_line_id_from_trip(route_id: str) -> str:
         routes_file = gtfs_path / "routes.txt"
         if routes_file.exists():
             with open(routes_file, "r", encoding="utf-8") as rf:
-                # Skip header line
-                header = next(rf).strip().split(",")
-                route_id_index = header.index("route_id")
-                route_short_name_index = header.index("route_short_name")
-
-                for route_line in rf:
-                    fields = route_line.strip().split(",")
-                    if (
-                        len(fields) > max(route_id_index, route_short_name_index)
-                        and fields[route_id_index] == route_id
-                    ):
+                reader = csv.DictReader(rf)
+                for row in reader:
+                    if strip_sncb_id_prefix(row["route_id"]) == route_id:
                         # Found the route, return the route_id as is since it's already in the correct format
                         return route_id
 
@@ -1452,43 +1426,9 @@ async def get_line_info() -> Dict[str, Dict[str, Any]]:
             return {}
 
         with open(routes_file, "r", encoding="utf-8") as f:
-            # Read header
-            header = f.readline().strip().split(",")
-            route_id_index = header.index("route_id")
-            route_short_name_index = header.index("route_short_name")
-            route_long_name_index = (
-                header.index("route_long_name") if "route_long_name" in header else -1
-            )
-            route_type_index = (
-                header.index("route_type") if "route_type" in header else -1
-            )
-            route_color_index = (
-                header.index("route_color") if "route_color" in header else -1
-            )
-            route_text_color_index = (
-                header.index("route_text_color") if "route_text_color" in header else -1
-            )
-
-            # Read routes
-            for line in f:
-                # Split by comma but preserve quoted fields
-                fields = []
-                current_field = []
-                in_quotes = False
-                for char in line.strip():
-                    if char == '"':
-                        in_quotes = not in_quotes
-                    elif char == "," and not in_quotes:
-                        fields.append("".join(current_field))
-                        current_field = []
-                    else:
-                        current_field.append(char)
-                fields.append("".join(current_field))
-
-                # Remove quotes from fields
-                fields = [f.strip('"') for f in fields]
-
-                route_id = strip_sncb_id_prefix(fields[route_id_index])
+            reader = csv.DictReader(f)
+            for row in reader:
+                route_id = strip_sncb_id_prefix(row["route_id"])
 
                 # Only include monitored lines
                 if route_id not in MONITORED_LINES:
@@ -1496,23 +1436,21 @@ async def get_line_info() -> Dict[str, Dict[str, Any]]:
 
                 info = {
                     "route_id": route_id,
-                    "display_name": fields[route_short_name_index],
+                    "display_name": row["route_short_name"],
                     "provider": "sncb",
                 }
 
                 # Add optional fields if available
-                if route_long_name_index >= 0:
-                    info["long_name"] = fields[route_long_name_index]
-                if route_type_index >= 0:
-                    info["route_type"] = int(fields[route_type_index])
-                if route_color_index >= 0 and len(fields) > route_color_index:
-                    color = fields[route_color_index].strip()
-                    if color:
-                        info["color"] = f"#{color}"
-                if route_text_color_index >= 0 and len(fields) > route_text_color_index:
-                    text_color = fields[route_text_color_index].strip()
-                    if text_color:
-                        info["text_color"] = f"#{text_color}"
+                if row.get("route_long_name"):
+                    info["long_name"] = row["route_long_name"]
+                if row.get("route_type"):
+                    info["route_type"] = int(row["route_type"])
+                color = (row.get("route_color") or "").strip()
+                if color:
+                    info["color"] = f"#{color}"
+                text_color = (row.get("route_text_color") or "").strip()
+                if text_color:
+                    info["text_color"] = f"#{text_color}"
 
                 line_info[route_id] = info
 

--- a/app/transit_providers/be/sncb/api.py
+++ b/app/transit_providers/be/sncb/api.py
@@ -1,6 +1,10 @@
 """SNCB (Belgium) transit provider API implementation"""
 
 import os
+import io
+import json
+import shutil
+import zipfile
 from datetime import datetime, timezone, timedelta
 from zoneinfo import ZoneInfo
 import logging
@@ -31,6 +35,13 @@ from asyncio import (
 )
 import time
 from schedule_explorer.backend.gtfs_loader import load_translations
+from transit_providers.be.mobility import mobility_subscription_headers
+from transit_providers.be.sncb_ids import (
+    normalize_sncb_stop_id,
+    normalize_static_gtfs_dir,
+    strip_sncb_id_prefix,
+    unwrap_gtfs_json_ints,
+)
 
 # Export public API functions
 __all__ = [
@@ -58,8 +69,15 @@ STOP_IDS = provider_config.get("STOP_IDS", [])
 GTFS_USED_FILES = provider_config.get("GTFS_USED_FILES", [])
 
 # GTFS-realtime endpoints
+REALTIME_SOURCE = str(
+    provider_config.get("REALTIME_SOURCE", "belgian_mobility")
+).lower()
+APIM_TRIP_UPDATES_URL = provider_config.get("APIM_TRIP_UPDATES_URL")
+LEGACY_TRIP_UPDATES_URL = provider_config.get("LEGACY_REALTIME_URL")
 REALTIME_URL = provider_config.get("REALTIME_URL")
-TRIP_UPDATES_URL = REALTIME_URL
+TRIP_UPDATES_URL = (
+    LEGACY_TRIP_UPDATES_URL if REALTIME_SOURCE == "legacy" else APIM_TRIP_UPDATES_URL
+)
 
 # Cache for stop and route information
 _stops_cache = {}
@@ -99,6 +117,42 @@ def get_directory_size(directory: Path) -> float:
             total_size += path.stat().st_size
     return total_size / (1024 * 1024)
 
+
+def _safe_extract_zip(zf: zipfile.ZipFile, dest_dir: Path) -> None:
+    """Extract ZIP members under dest_dir only."""
+    dest_root = dest_dir.resolve()
+    for member in zf.infolist():
+        name = member.filename
+        if not name or name.endswith("/"):
+            continue
+        target = (dest_root / name).resolve()
+        try:
+            target.relative_to(dest_root)
+        except ValueError:
+            logger.warning("Skipping ZIP entry outside GTFS dir: %s", name)
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with zf.open(member, "r") as src, open(target, "wb") as out_f:
+            shutil.copyfileobj(src, out_f)
+
+
+def _required_gtfs_files() -> List[str]:
+    return ["stops.txt", "routes.txt", "trips.txt", "stop_times.txt"]
+
+
+def _gtfs_dir_has_required_files(path: Path) -> bool:
+    return path.exists() and all(
+        (path / filename).exists() for filename in _required_gtfs_files()
+    )
+
+
+def _cache_duration_seconds() -> int:
+    duration = provider_config.get("GTFS_CACHE_DURATION", 86400 * 7)
+    if isinstance(duration, timedelta):
+        return int(duration.total_seconds())
+    return int(duration)
+
+
 def _load_stop_times_cache() -> None:
     """Load stop times from GTFS data into cache"""
     global _stop_times_cache, _stop_times_cache_update
@@ -121,17 +175,17 @@ def _load_stop_times_cache() -> None:
 
             for line in f:
                 fields = line.strip().split(",")
-                trip_id = fields[trip_id_index].strip('"')
-                stop_id = fields[stop_id_index].strip('"')
-                # Remove any suffix after underscore (e.g. 8814001_7 -> 8814001)
-                base_stop_id = stop_id.split("_")[0]
+                trip_id = strip_sncb_id_prefix(fields[trip_id_index].strip('"'))
+                stop_id = normalize_sncb_stop_id(
+                    fields[stop_id_index].strip('"'), collapse_platform=True
+                )
 
                 if trip_id not in new_cache:
                     new_cache[trip_id] = []
 
                 new_cache[trip_id].append(
                     {
-                        "stop_id": base_stop_id,
+                        "stop_id": stop_id,
                         "stop_sequence": int(fields[stop_sequence_index]),
                     }
                 )
@@ -180,8 +234,8 @@ def _load_trips_cache() -> None:
                 if len(fields) > max(
                     trip_id_index, trip_headsign_index, route_id_index
                 ):
-                    route_id = fields[route_id_index].strip('"')
-                    trip_id = fields[trip_id_index].strip('"')
+                    route_id = strip_sncb_id_prefix(fields[route_id_index].strip('"'))
+                    trip_id = strip_sncb_id_prefix(fields[trip_id_index].strip('"'))
                     headsign = fields[trip_headsign_index].strip('"')
 
                     trip_data = {
@@ -288,33 +342,136 @@ async def _initialize_caches():
 
 
 class GTFSManager:
-    """Manages GTFS data download and caching using mobility-db-api"""
+    """Manages SNCB static GTFS data download and caching."""
 
     def __init__(self):
         # Get GTFS directory from config or use default
-        self.gtfs_dir = (
+        self.gtfs_dir = Path(
             provider_config.get("GTFS_DIR")
             or Path(os.environ["PROJECT_ROOT"]) / "downloads"
         )
+        cache_dir = Path(
+            provider_config.get("CACHE_DIR")
+            or Path(os.environ["PROJECT_ROOT"]) / "cache" / "sncb"
+        )
+        self.apim_gtfs_dir = Path(
+            provider_config.get("GTFS_STATIC_DIR") or (cache_dir / "gtfs")
+        )
+        self.apim_metadata_file = Path(
+            provider_config.get("GTFS_STATIC_METADATA_FILE")
+            or (self.apim_gtfs_dir / "metadata.json")
+        )
+        self.current_gtfs_path: Optional[Path] = None
+        self.mobility_api: Optional[MobilityAPI] = None
         logger.info(f"Initializing GTFSManager with directory: {self.gtfs_dir}")
 
         # Create GTFS directory if it doesn't exist
         self.gtfs_dir.mkdir(parents=True, exist_ok=True)
+        self.apim_gtfs_dir.mkdir(parents=True, exist_ok=True)
 
         # Check for refresh token
         refresh_token = os.getenv("MOBILITY_API_REFRESH_TOKEN")
         if not refresh_token:
-            logger.error(
+            logger.warning(
                 "MOBILITY_API_REFRESH_TOKEN not found in environment variables. "
-                "GTFS data download from Mobility Database will not be available. "
-                "Please add MOBILITY_API_REFRESH_TOKEN to your .env file."
+                "Static GTFS fallback through Mobility Database will not be available."
+            )
+        else:
+            self.mobility_api = MobilityAPI(
+                data_dir=str(self.gtfs_dir),
+                refresh_token=refresh_token,
+            )
+
+    def _apim_cache_is_valid(self) -> bool:
+        if not _gtfs_dir_has_required_files(self.apim_gtfs_dir):
+            return False
+        if not self.apim_metadata_file.exists():
+            return False
+        try:
+            metadata = json.loads(self.apim_metadata_file.read_text())
+            downloaded_at = datetime.fromisoformat(metadata["downloaded_at"])
+            if downloaded_at.tzinfo is None:
+                downloaded_at = downloaded_at.replace(tzinfo=timezone.utc)
+        except (KeyError, ValueError, json.JSONDecodeError, OSError) as exc:
+            logger.warning("Ignoring invalid SNCB APIM GTFS metadata: %s", exc)
+            return False
+
+        age = datetime.now(timezone.utc) - downloaded_at
+        return age.total_seconds() < _cache_duration_seconds()
+
+    async def _download_apim_static_gtfs(self) -> Optional[Path]:
+        url = provider_config.get("GTFS_STATIC_URL")
+        if not url:
+            logger.error("SNCB GTFS_STATIC_URL is not configured")
+            return None
+
+        headers = mobility_subscription_headers("sncb")
+        if not headers:
+            logger.error(
+                "MOBILITY_API_PRIMARY_KEY or MOBILITY_API_SECONDARY_KEY is required "
+                "for SNCB Belgian Mobility static GTFS"
             )
             return None
 
-        self.mobility_api = MobilityAPI(
-            data_dir=str(self.gtfs_dir),
-            refresh_token=refresh_token,
-        )
+        tmp_dir = self.apim_gtfs_dir.parent / f".{self.apim_gtfs_dir.name}.tmp"
+        if tmp_dir.exists():
+            shutil.rmtree(tmp_dir)
+        tmp_dir.mkdir(parents=True)
+
+        try:
+            timeout = httpx.Timeout(120.0, connect=10.0)
+            async with httpx.AsyncClient(
+                timeout=timeout, follow_redirects=True
+            ) as client:
+                response = await client.get(url, headers=headers)
+                response.raise_for_status()
+
+            with zipfile.ZipFile(io.BytesIO(response.content), "r") as zf:
+                _safe_extract_zip(zf, tmp_dir)
+
+            normalize_static_gtfs_dir(tmp_dir)
+
+            if not _gtfs_dir_has_required_files(tmp_dir):
+                missing = [
+                    filename
+                    for filename in _required_gtfs_files()
+                    if not (tmp_dir / filename).exists()
+                ]
+                logger.error("SNCB APIM GTFS download missing files: %s", missing)
+                shutil.rmtree(tmp_dir)
+                return None
+
+            if self.apim_gtfs_dir.exists():
+                shutil.rmtree(self.apim_gtfs_dir)
+            tmp_dir.rename(self.apim_gtfs_dir)
+            self.apim_gtfs_dir.mkdir(parents=True, exist_ok=True)
+
+            metadata = {
+                "downloaded_at": datetime.now(timezone.utc).isoformat(),
+                "source": "belgian_mobility",
+                "source_url": url,
+                "last_modified": response.headers.get("last-modified"),
+                "etag": response.headers.get("etag"),
+            }
+            self.apim_metadata_file.parent.mkdir(parents=True, exist_ok=True)
+            self.apim_metadata_file.write_text(json.dumps(metadata, indent=2))
+
+            logger.info(
+                "Downloaded SNCB Belgian Mobility GTFS to %s (%.2f MB)",
+                self.apim_gtfs_dir,
+                get_directory_size(self.apim_gtfs_dir),
+            )
+            return self.apim_gtfs_dir
+        except Exception as exc:
+            logger.error("Error downloading SNCB Belgian Mobility GTFS: %s", exc)
+            if tmp_dir.exists():
+                shutil.rmtree(tmp_dir)
+            return None
+
+    async def _ensure_apim_gtfs_data(self) -> Optional[Path]:
+        if self._apim_cache_is_valid():
+            return self.apim_gtfs_dir
+        return await self._download_apim_static_gtfs()
 
     def _is_dataset_expired(self, dataset) -> bool:
         """Check if dataset needs updating"""
@@ -369,8 +526,20 @@ class GTFSManager:
         try:
             logger.info(f"Ensuring GTFS data in directory: {self.gtfs_dir}")
 
+            static_source = str(
+                provider_config.get("GTFS_STATIC_SOURCE", "belgian_mobility")
+            ).lower()
+            if static_source == "belgian_mobility":
+                apim_path = await self._ensure_apim_gtfs_data()
+                if apim_path:
+                    self.current_gtfs_path = apim_path
+                    return apim_path
+                logger.warning(
+                    "Falling back to Mobility Database for SNCB static GTFS"
+                )
+
             # Check if we have a refresh token
-            if not os.getenv("MOBILITY_API_REFRESH_TOKEN"):
+            if self.mobility_api is None:
                 logger.error(
                     "MOBILITY_API_REFRESH_TOKEN not found in environment variables. "
                     "GTFS data download from Mobility Database will not be available. "
@@ -390,9 +559,11 @@ class GTFSManager:
                 if not dataset_path:
                     logger.error("Failed to download GTFS data")
                     return None
-                return Path(dataset_path)
+                self.current_gtfs_path = Path(dataset_path)
+                return self.current_gtfs_path
 
-            return Path(current_dataset.download_path)
+            self.current_gtfs_path = Path(current_dataset.download_path)
+            return self.current_gtfs_path
 
         except Exception as e:
             logger.error(f"Error ensuring GTFS data: {e}")
@@ -425,23 +596,33 @@ def _load_stops_cache() -> None:
             return
 
         new_cache = {}
+        stop_aliases = {}
         with open(stops_file, "r", encoding="utf-8") as f:
             import csv
 
             reader = csv.DictReader(f)
 
             for row in reader:
-                stop_id = row["stop_id"].strip()
+                stop_id = strip_sncb_id_prefix(row["stop_id"].strip())
                 try:
-                    new_cache[stop_id] = {
+                    stop_info = {
                         "name": row["stop_name"].strip(),
                         "lat": float(row["stop_lat"].strip()),
                         "lon": float(row["stop_lon"].strip()),
                         "translations": translations.get(stop_id, {}),
                     }
+                    new_cache[stop_id] = stop_info
+                    if "_" in stop_id:
+                        base_stop_id = normalize_sncb_stop_id(
+                            stop_id, collapse_platform=True
+                        )
+                        stop_aliases.setdefault(base_stop_id, stop_info)
                 except (ValueError, KeyError) as e:
                     logger.error(f"Error parsing stop data for {stop_id}: {e}")
                     continue
+
+        for stop_id, stop_info in stop_aliases.items():
+            new_cache.setdefault(stop_id, stop_info)
 
         _stops_cache = new_cache
         _stops_cache_update = datetime.now(timezone.utc)
@@ -481,7 +662,7 @@ def _load_routes_cache() -> None:
 
             for line in f:
                 fields = line.strip().split(",")
-                route_id = fields[route_id_index]
+                route_id = strip_sncb_id_prefix(fields[route_id_index])
                 new_cache[route_id] = {
                     "route_short_name": fields[route_short_name_index],
                     "route_desc": (
@@ -661,6 +842,67 @@ def _get_trip_route(trip_id: str) -> List[Dict[str, str]]:
         return []
 
 
+def _normalize_realtime_feed_ids(feed: gtfs_realtime_pb2.FeedMessage) -> None:
+    """Normalize Belgian Mobility SNCB IDs in a parsed GTFS-RT message."""
+    for entity in feed.entity:
+        if entity.HasField("trip_update"):
+            trip_update = entity.trip_update
+            trip = trip_update.trip
+            if trip.trip_id:
+                trip.trip_id = strip_sncb_id_prefix(trip.trip_id)
+            if trip.route_id:
+                trip.route_id = strip_sncb_id_prefix(trip.route_id)
+            for stop_time in trip_update.stop_time_update:
+                if stop_time.stop_id:
+                    stop_time.stop_id = normalize_sncb_stop_id(
+                        stop_time.stop_id, collapse_platform=True
+                    )
+
+        if entity.HasField("vehicle"):
+            vehicle = entity.vehicle
+            if vehicle.trip.trip_id:
+                vehicle.trip.trip_id = strip_sncb_id_prefix(vehicle.trip.trip_id)
+            if vehicle.trip.route_id:
+                vehicle.trip.route_id = strip_sncb_id_prefix(vehicle.trip.route_id)
+            if vehicle.stop_id:
+                vehicle.stop_id = normalize_sncb_stop_id(
+                    vehicle.stop_id, collapse_platform=True
+                )
+
+
+async def _fetch_trip_updates_feed(
+    client: httpx.AsyncClient,
+) -> gtfs_realtime_pb2.FeedMessage:
+    """Fetch SNCB trip updates from the configured realtime source."""
+    if REALTIME_SOURCE == "legacy":
+        if not LEGACY_TRIP_UPDATES_URL:
+            raise RuntimeError(
+                "SNCB_REALTIME_SOURCE=legacy requires "
+                "SNCB_LEGACY_GTFS_REALTIME_API_URL"
+            )
+        response = await client.get(LEGACY_TRIP_UPDATES_URL)
+        response.raise_for_status()
+        feed = gtfs_realtime_pb2.FeedMessage()
+        feed.ParseFromString(response.content)
+        _normalize_realtime_feed_ids(feed)
+        return feed
+
+    headers = mobility_subscription_headers("sncb")
+    if not headers:
+        raise RuntimeError(
+            "MOBILITY_API_PRIMARY_KEY or MOBILITY_API_SECONDARY_KEY is required "
+            "for SNCB Belgian Mobility realtime"
+        )
+    response = await client.get(APIM_TRIP_UPDATES_URL, headers=headers)
+    response.raise_for_status()
+    feed = gtfs_realtime_pb2.FeedMessage()
+    json_format.ParseDict(
+        unwrap_gtfs_json_ints(response.json()), feed, ignore_unknown_fields=True
+    )
+    _normalize_realtime_feed_ids(feed)
+    return feed
+
+
 async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict:
     """Get waiting times for stops.
 
@@ -699,6 +941,9 @@ async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict:
                 stop_ids = stop_id
         else:
             stop_ids = config.get("STOP_IDS", [])
+        stop_ids = [
+            normalize_sncb_stop_id(str(s), collapse_platform=True) for s in stop_ids
+        ]
 
         perf_data["config_time"] = time.time() - config_start
 
@@ -785,14 +1030,12 @@ async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict:
             # Make API request
             api_request_start = time.time()
             async with httpx.AsyncClient(timeout=timeout, limits=limits) as client:
-                response = await client.get(TRIP_UPDATES_URL)
-                response.raise_for_status()
+                feed = await _fetch_trip_updates_feed(client)
             perf_data["api_request_time"] = time.time() - api_request_start
+            perf_data["realtime_source"] = REALTIME_SOURCE
 
             # Parse feed
             feed_parse_start = time.time()
-            feed = gtfs_realtime_pb2.FeedMessage()
-            feed.ParseFromString(response.content)
             perf_data["feed_parse_time"] = time.time() - feed_parse_start
 
             # Pre-load route info for all monitored lines to avoid repeated cache checks
@@ -1047,6 +1290,15 @@ async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict:
 def _get_current_gtfs_path() -> Optional[Path]:
     """Get the path to the current GTFS dataset"""
     try:
+        if gtfs_manager is not None:
+            current_path = getattr(gtfs_manager, "current_gtfs_path", None)
+            if current_path and Path(current_path).exists():
+                return Path(current_path)
+
+            apim_path = getattr(gtfs_manager, "apim_gtfs_dir", None)
+            if apim_path and _gtfs_dir_has_required_files(Path(apim_path)):
+                return Path(apim_path)
+
         # First try reading from metadata file
         metadata_file = GTFS_DIR / "datasets_metadata.json"
         if metadata_file.exists():
@@ -1070,7 +1322,7 @@ def _get_current_gtfs_path() -> Optional[Path]:
                     return Path(latest[1]["download_path"])
 
         # Fallback to using MobilityAPI
-        if gtfs_manager is None:
+        if gtfs_manager is None or gtfs_manager.mobility_api is None:
             logger.error("GTFSManager not initialized")
             return None
 
@@ -1089,6 +1341,7 @@ def _get_current_gtfs_path() -> Optional[Path]:
 
 def _get_line_id_from_trip(route_id: str) -> str:
     """Extract line ID from route ID based on GTFS data structure"""
+    route_id = strip_sncb_id_prefix(route_id)
     try:
         # First try direct route ID to route short name mapping from routes.txt
         gtfs_dir = GTFS_DIR
@@ -1235,7 +1488,7 @@ async def get_line_info() -> Dict[str, Dict[str, Any]]:
                 # Remove quotes from fields
                 fields = [f.strip('"') for f in fields]
 
-                route_id = fields[route_id_index]
+                route_id = strip_sncb_id_prefix(fields[route_id_index])
 
                 # Only include monitored lines
                 if route_id not in MONITORED_LINES:
@@ -1267,10 +1520,6 @@ async def get_line_info() -> Dict[str, Dict[str, Any]]:
     except Exception as e:
         logger.error(f"Error getting line information: {e}")
         return {}
-
-
-# Initialize GTFSManager
-gtfs_manager = GTFSManager()
 
 
 # Initialize caches at module load
@@ -1356,5 +1605,3 @@ except RuntimeError:
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 loop.run_until_complete(_ensure_caches_initialized())
-
-

--- a/app/transit_providers/be/sncb/config.py
+++ b/app/transit_providers/be/sncb/config.py
@@ -3,24 +3,43 @@
 import os
 from pathlib import Path
 from transit_providers.config import register_provider_config
+from transit_providers.be.mobility import mobility_url
 
 # Get the project root from environment variable (set by start.py)
 PROJECT_ROOT = Path(os.environ["PROJECT_ROOT"])
+SNCB_CACHE_DIR = PROJECT_ROOT / "cache" / "sncb"
 
 # Default configuration
 DEFAULT_CONFIG = {
     "PROVIDER_ID": "mdb-1859",  # SNCB's ID in Mobility Database
     "API_KEY": os.getenv("SNCB_API_KEY"),
-    "CACHE_DIR": PROJECT_ROOT / "cache" / "sncb",
+    "MOBILITY_API_PRIMARY_KEY": os.getenv("MOBILITY_API_PRIMARY_KEY"),
+    "MOBILITY_API_SECONDARY_KEY": os.getenv("MOBILITY_API_SECONDARY_KEY"),
+    "CACHE_DIR": SNCB_CACHE_DIR,
     "GTFS_DIR": PROJECT_ROOT / "downloads",
+    "GTFS_STATIC_SOURCE": os.getenv("SNCB_GTFS_STATIC_SOURCE", "belgian_mobility"),
+    "GTFS_STATIC_URL": os.getenv(
+        "SNCB_GTFS_STATIC_URL",
+        mobility_url("/api/gtfs/feed/nmbssncb/static"),
+    ),
+    "GTFS_STATIC_DIR": SNCB_CACHE_DIR / "gtfs",
+    "GTFS_STATIC_METADATA_FILE": SNCB_CACHE_DIR / "gtfs" / "metadata.json",
     "STOP_IDS": [
         "8813003"  # Brussels Central as a test stop
     ],  # Should be set in local config
     "MONITORED_LINES": [],  # Should be set in local config
     "RATE_LIMIT_DELAY": 0.5,  # seconds between API calls
     "GTFS_CACHE_DURATION": 86400 * 7,  # 7 days in seconds
+    "REALTIME_SOURCE": os.getenv("SNCB_REALTIME_SOURCE", "belgian_mobility"),
+    "APIM_TRIP_UPDATES_URL": os.getenv(
+        "SNCB_BELGIAN_MOBILITY_TRIP_UPDATES_URL",
+        mobility_url("/api/gtfs/feed/nmbssncb/rt/trip-update"),
+    ),
+    "LEGACY_REALTIME_URL": os.getenv("SNCB_LEGACY_GTFS_REALTIME_API_URL")
+    or os.getenv("SNCB_GTFS_REALTIME_API_URL"),
     "REALTIME_URL": os.getenv(
-        "SNCB_GTFS_REALTIME_API_URL", "https://data.gtfs.be/sncb/gtfs/tripUpdates.pb"
+        "SNCB_BELGIAN_MOBILITY_TRIP_UPDATES_URL",
+        mobility_url("/api/gtfs/feed/nmbssncb/rt/trip-update"),
     ),
 }
 

--- a/app/transit_providers/be/sncb/readme.md
+++ b/app/transit_providers/be/sncb/readme.md
@@ -7,8 +7,13 @@
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
 
-Sign an agreement with SNCB to be able to use their data: https://www.belgiantrain.be/en/3rd-party-services/mobility-service-providers/public-data
+SNCB/NMBS now directs public timetable users to Belgian Mobility: https://www.belgiantrain.be/en/3rd-party-services/mobility-service-providers/public-data
 
-Once you have the agreement signed by both parties, you will get a URL to a page with the datasets. Copy the adress of the GTFS realtime endpoint and add it to the .env file as SNCB_GTFS_REALTIME_API_URL.
+The provider uses Belgian Mobility APIM by default:
 
-As a fallback you can use the GTFS mirror at [https://data.gtfs.be/sncb/gtfs/tripUpdates.pb](https://data.gtfs.be/sncb/gtfs/tripUpdates.pb) provided by [GTFS.be](https://gtfs.be).
+- Static GTFS: `/api/gtfs/feed/nmbssncb/static`
+- Realtime trip updates: `/api/gtfs/feed/nmbssncb/rt/trip-update`
+
+Set `MOBILITY_API_PRIMARY_KEY` or `MOBILITY_API_SECONDARY_KEY` in `.env`. The app sends the key as the `bmc-partner-key` header.
+
+The old SNCB GTFS-RT URL can still be used only by setting `SNCB_REALTIME_SOURCE=legacy` and `SNCB_LEGACY_GTFS_REALTIME_API_URL`. GTFS.be remains useful for static GTFS fallback through Mobility Database, but its `tripUpdates.pb` mirror is not used because it is not reliably live.

--- a/app/transit_providers/be/sncb_ids.py
+++ b/app/transit_providers/be/sncb_ids.py
@@ -1,0 +1,88 @@
+"""SNCB/NMBS identifier normalization helpers."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+from typing import Any
+
+SNCB_ID_PREFIXES = (
+    "gt:nmbssncb:",
+    "gs:nmbssncb:",
+    "gr:nmbssncb:",
+    "gc:nmbssncb:",
+    "nmbssncb:",
+)
+
+GTFS_ID_COLUMNS = {
+    "agency.txt": {"agency_id"},
+    "calendar.txt": {"service_id"},
+    "calendar_dates.txt": {"service_id"},
+    "routes.txt": {"agency_id", "route_id"},
+    "stop_times.txt": {"stop_id", "trip_id"},
+    "stops.txt": {"parent_station", "stop_id"},
+    "transfers.txt": {
+        "from_route_id",
+        "from_stop_id",
+        "from_trip_id",
+        "to_route_id",
+        "to_stop_id",
+        "to_trip_id",
+    },
+    "trips.txt": {"block_id", "route_id", "service_id", "shape_id", "trip_id"},
+}
+
+
+def strip_sncb_id_prefix(value: str) -> str:
+    """Strip Belgian Mobility SNCB prefixes while leaving legacy IDs unchanged."""
+    for prefix in SNCB_ID_PREFIXES:
+        if value.startswith(prefix):
+            return value[len(prefix) :]
+    return value
+
+
+def normalize_sncb_stop_id(value: str, collapse_platform: bool = False) -> str:
+    """Normalize an SNCB stop ID, optionally collapsing platform IDs to station IDs."""
+    out = strip_sncb_id_prefix(value)
+    if collapse_platform and "_" in out:
+        return out.split("_", 1)[0]
+    return out
+
+
+def unwrap_gtfs_json_ints(value: Any) -> Any:
+    """Convert protobufjs-style Long JSON objects into Python integers."""
+    if isinstance(value, dict):
+        if "low" in value and "high" in value:
+            low = int(value.get("low") or 0)
+            high = int(value.get("high") or 0)
+            return (high << 32) + (low & 0xFFFFFFFF)
+        return {key: unwrap_gtfs_json_ints(val) for key, val in value.items()}
+    if isinstance(value, list):
+        return [unwrap_gtfs_json_ints(item) for item in value]
+    return value
+
+
+def normalize_static_gtfs_dir(gtfs_dir: Path) -> None:
+    """Normalize Belgian Mobility GTFS IDs in-place to this provider's legacy ID shape."""
+    for filename, columns in GTFS_ID_COLUMNS.items():
+        path = gtfs_dir / filename
+        if path.exists():
+            _normalize_static_gtfs_file(path, columns)
+
+
+def _normalize_static_gtfs_file(path: Path, columns: set[str]) -> None:
+    with path.open("r", encoding="utf-8", newline="") as in_file:
+        reader = csv.DictReader(in_file)
+        if not reader.fieldnames:
+            return
+        rows = []
+        for row in reader:
+            for column in columns:
+                if column in row and row[column]:
+                    row[column] = strip_sncb_id_prefix(row[column])
+            rows.append(row)
+
+    with path.open("w", encoding="utf-8", newline="") as out_file:
+        writer = csv.DictWriter(out_file, fieldnames=reader.fieldnames)
+        writer.writeheader()
+        writer.writerows(rows)

--- a/app/transit_providers/be/sncb_ids.py
+++ b/app/transit_providers/be/sncb_ids.py
@@ -71,18 +71,23 @@ def normalize_static_gtfs_dir(gtfs_dir: Path) -> None:
 
 
 def _normalize_static_gtfs_file(path: Path, columns: set[str]) -> None:
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
     with path.open("r", encoding="utf-8", newline="") as in_file:
         reader = csv.DictReader(in_file)
         if not reader.fieldnames:
             return
-        rows = []
-        for row in reader:
-            for column in columns:
-                if column in row and row[column]:
-                    row[column] = strip_sncb_id_prefix(row[column])
-            rows.append(row)
 
-    with path.open("w", encoding="utf-8", newline="") as out_file:
-        writer = csv.DictWriter(out_file, fieldnames=reader.fieldnames)
-        writer.writeheader()
-        writer.writerows(rows)
+        try:
+            with tmp_path.open("w", encoding="utf-8", newline="") as out_file:
+                writer = csv.DictWriter(out_file, fieldnames=reader.fieldnames)
+                writer.writeheader()
+                for row in reader:
+                    for column in columns:
+                        if row.get(column):
+                            row[column] = strip_sncb_id_prefix(row[column])
+                    writer.writerow(row)
+            tmp_path.replace(path)
+        except Exception:
+            if tmp_path.exists():
+                tmp_path.unlink()
+            raise

--- a/app/transit_providers/be/test_mobility.py
+++ b/app/transit_providers/be/test_mobility.py
@@ -1,0 +1,45 @@
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+_APP_DIR = Path(__file__).resolve().parents[2]
+os.environ.setdefault("PROJECT_ROOT", str(_APP_DIR))
+if str(_APP_DIR) not in sys.path:
+    sys.path.insert(0, str(_APP_DIR))
+
+_MODULE_PATH = Path(__file__).with_name("mobility.py")
+_SPEC = importlib.util.spec_from_file_location("mobility_under_test", _MODULE_PATH)
+mobility = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(mobility)
+
+mobility_apim_base_url = mobility.mobility_apim_base_url
+mobility_subscription_headers = mobility.mobility_subscription_headers
+
+
+def test_mobility_apim_base_url_reads_top_level_config(monkeypatch):
+    monkeypatch.delenv("MOBILITY_APIM_BASE_URL", raising=False)
+
+    def fake_get_config(key, default=None):
+        values = {"MOBILITY_APIM_BASE_URL": "https://example.test/"}
+        return values.get(key, default)
+
+    monkeypatch.setattr(mobility, "get_config", fake_get_config)
+
+    assert mobility_apim_base_url() == "https://example.test"
+
+
+def test_mobility_subscription_headers_reads_top_level_config(monkeypatch):
+    monkeypatch.delenv("MOBILITY_API_PRIMARY_KEY", raising=False)
+    monkeypatch.delenv("MOBILITY_API_SECONDARY_KEY", raising=False)
+
+    def fake_get_config(key, default=None):
+        values = {"MOBILITY_API_PRIMARY_KEY": "top-level-key"}
+        return values.get(key, default)
+
+    monkeypatch.setattr(mobility, "get_config", fake_get_config)
+    monkeypatch.setattr(mobility, "get_provider_config", lambda provider: {})
+
+    assert mobility_subscription_headers("sncb") == {
+        "bmc-partner-key": "top-level-key"
+    }

--- a/app/transit_providers/be/test_sncb_ids.py
+++ b/app/transit_providers/be/test_sncb_ids.py
@@ -1,0 +1,100 @@
+import csv
+import importlib.util
+from pathlib import Path
+
+_MODULE_PATH = Path(__file__).with_name("sncb_ids.py")
+_SPEC = importlib.util.spec_from_file_location("sncb_ids_under_test", _MODULE_PATH)
+sncb_ids = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(sncb_ids)
+
+normalize_sncb_stop_id = sncb_ids.normalize_sncb_stop_id
+normalize_static_gtfs_dir = sncb_ids.normalize_static_gtfs_dir
+strip_sncb_id_prefix = sncb_ids.strip_sncb_id_prefix
+unwrap_gtfs_json_ints = sncb_ids.unwrap_gtfs_json_ints
+
+
+def test_strip_sncb_id_prefix_keeps_legacy_ids():
+    assert strip_sncb_id_prefix("gt:nmbssncb:88____:007") == "88____:007"
+    assert strip_sncb_id_prefix("gs:nmbssncb:8813003_3") == "8813003_3"
+    assert strip_sncb_id_prefix("gr:nmbssncb:60") == "60"
+    assert strip_sncb_id_prefix("8813003") == "8813003"
+
+
+def test_normalize_sncb_stop_id_can_collapse_platform_suffix():
+    assert normalize_sncb_stop_id("gs:nmbssncb:8813003_3") == "8813003_3"
+    assert (
+        normalize_sncb_stop_id("gs:nmbssncb:8813003_3", collapse_platform=True)
+        == "8813003"
+    )
+
+
+def test_unwrap_gtfs_json_ints_converts_protobufjs_long_objects():
+    payload = {
+        "header": {"timestamp": {"low": 1782048998, "high": 0, "unsigned": True}},
+        "entity": [{"timestamp": {"low": 1, "high": 1, "unsigned": True}}],
+    }
+
+    assert unwrap_gtfs_json_ints(payload) == {
+        "header": {"timestamp": 1782048998},
+        "entity": [{"timestamp": 4294967297}],
+    }
+
+
+def test_normalize_static_gtfs_dir_rewrites_belgian_mobility_ids(tmp_path):
+    _write_csv(
+        tmp_path / "stops.txt",
+        ["stop_id", "parent_station", "stop_name"],
+        [["gs:nmbssncb:8813003_3", "gs:nmbssncb:S8813003", "Bruxelles-Central"]],
+    )
+    _write_csv(
+        tmp_path / "trips.txt",
+        ["route_id", "service_id", "trip_id"],
+        [
+            [
+                "gr:nmbssncb:60",
+                "gc:nmbssncb:000071",
+                "gt:nmbssncb:88____:046::8833001:8833209:3:2242:20260918",
+            ]
+        ],
+    )
+    _write_csv(
+        tmp_path / "stop_times.txt",
+        ["trip_id", "stop_id", "stop_sequence"],
+        [
+            [
+                "gt:nmbssncb:88____:046::8833001:8833209:3:2242:20260918",
+                "gs:nmbssncb:8813003_3",
+                "1",
+            ]
+        ],
+    )
+
+    normalize_static_gtfs_dir(tmp_path)
+
+    assert _read_csv(tmp_path / "stops.txt")[0] == {
+        "stop_id": "8813003_3",
+        "parent_station": "S8813003",
+        "stop_name": "Bruxelles-Central",
+    }
+    assert _read_csv(tmp_path / "trips.txt")[0] == {
+        "route_id": "60",
+        "service_id": "000071",
+        "trip_id": "88____:046::8833001:8833209:3:2242:20260918",
+    }
+    assert _read_csv(tmp_path / "stop_times.txt")[0] == {
+        "trip_id": "88____:046::8833001:8833209:3:2242:20260918",
+        "stop_id": "8813003_3",
+        "stop_sequence": "1",
+    }
+
+
+def _write_csv(path, fieldnames, rows):
+    with path.open("w", encoding="utf-8", newline="") as f:
+        writer = csv.writer(f)
+        writer.writerow(fieldnames)
+        writer.writerows(rows)
+
+
+def _read_csv(path):
+    with path.open("r", encoding="utf-8", newline="") as f:
+        return list(csv.DictReader(f))

--- a/readme.md
+++ b/readme.md
@@ -128,12 +128,14 @@ DELIJN_GTFS_REALTIME_API_KEY)
 
 ### SNCB (Belgium)
 
-Note that the app works without signing an agreement with SNCB through the mirrored data provided by [GTFS.be](https://gtfs.be/).
+SNCB/NMBS now publishes scheduled and realtime GTFS data through the [Belgian Mobility Open Data Portal](https://data.belgianmobility.io/).
 
-1. Visit https://opendata.sncb.be/
-2. Register and request an agreement
-3. Once both parties have signed the agreement, you will receive a link to a page where the GTFS real time feed is linked
-4. Add the url to your `.env` file as "SNCB_GTFS_REALTIME_API_URL"
+1. Visit https://api-management-opendata-production.developer.azure-api.net/
+2. Create an account and subscribe to the Standard product.
+3. Add the primary or secondary key to `.env` as `MOBILITY_API_PRIMARY_KEY` or `MOBILITY_API_SECONDARY_KEY`.
+4. Optional static fallback: add `MOBILITY_API_REFRESH_TOKEN` so the app can fall back to Mobility Database / GTFS.be static GTFS if Belgian Mobility static GTFS is temporarily unavailable.
+
+The old `SNCB_GTFS_REALTIME_API_URL` setting is deprecated. GTFS.be's `tripUpdates.pb` mirror is not used as a realtime fallback because it is not reliably updated.
 
 ### BKK (Budapest)
 


### PR DESCRIPTION
## Summary
- switch SNCB/NMBS static GTFS and realtime trip updates to Belgian Mobility APIM as the primary source
- normalize Belgian Mobility SNCB IDs back to the provider's existing stop/route/trip ID shape so current configuration remains compatible
- keep Mobility Database / GTFS.be as a static GTFS fallback and keep legacy GTFS-RT available only via explicit opt-in
- update `.env.example`, local config template, Docker/docs, provider docs, and changelog for the new APIM key requirement

## Config impact
- `MOBILITY_API_PRIMARY_KEY` or `MOBILITY_API_SECONDARY_KEY` is now required for the default SNCB realtime/static path
- `MOBILITY_API_REFRESH_TOKEN` is optional and only needed for the static GTFS fallback
- `SNCB_GTFS_REALTIME_API_URL` is deprecated; use `SNCB_REALTIME_SOURCE=legacy` plus `SNCB_LEGACY_GTFS_REALTIME_API_URL` only for explicit legacy protobuf use

## Validation
- `git diff --check`
- `.venv/bin/python -m compileall app/transit_providers/be/sncb/api.py app/transit_providers/be/mobility.py app/transit_providers/be/sncb_ids.py`
- `PYTHONPATH=app ENABLED_PROVIDERS=__none__ PROJECT_ROOT=/Users/bence/Developer/STIB/app .venv/bin/python -m pytest app/transit_providers/be/test_sncb_ids.py app/transit_providers/be/test_mobility.py -q` -> 6 passed
- live SNCB smoke with local `.env`: `get_waiting_times(['8813003'])` used `app/cache/sncb/gtfs`, `realtime_source=belgian_mobility`, `error=None`, stop `Bruxelles-Central`, 6 lines

## Notes
- The broader STIB helper test collection still has an existing provider import/config side effect when providers are disabled, so I kept the automated run focused on the new shared APIM helper and SNCB ID normalization.
- After review/CI passes and this is merged, cut a new release because default SNCB operation now requires the Belgian Mobility APIM subscription key.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated configuration examples and setup guides for Belgian SNCB/NMBS transit data
  * Documented Belgian Mobility API authentication and credential requirements

* **New Features**
  * Migrated SNCB/NMBS to Belgian Mobility as primary data source for schedules and real-time updates
  * Added API authentication via new subscription keys for secure data access

<!-- end of auto-generated comment: release notes by coderabbit.ai -->