### PR TITLE
Add Le TEC Belgian Mobility provider

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -21,6 +21,14 @@ MOBILITY_API_REFRESH_TOKEN=your-mobility-api-refresh-token-here
 # Legacy/deprecated realtime source, only used with SNCB_REALTIME_SOURCE=legacy:
 # SNCB_LEGACY_GTFS_REALTIME_API_URL=your-legacy-sncb-gtfs-realtime-url
 
+# Le TEC uses Belgian Mobility APIM by default for static GTFS, GTFS-RT trip updates,
+# and GTFS-RT service alerts. The local provider id is "letec"; the APIM feed slug
+# remains "tec".
+# LETEC_GTFS_STATIC_URL=https://api-management-opendata-production.azure-api.net/api/gtfs/feed/tec/static
+# LETEC_GTFS_RT_TRIP_UPDATES_URL=https://api-management-opendata-production.azure-api.net/api/gtfs/feed/tec/rt/trip-update
+# LETEC_GTFS_RT_SERVICE_ALERTS_URL=https://api-management-opendata-production.azure-api.net/api/gtfs/feed/tec/rt/alert
+# LETEC_GTFS_STATIC_FALLBACK_URL=https://opendata.tec-wl.be/Current%20GTFS/TEC-GTFS.zip
+
 # Schedule Explorer Configuration
 # For local development:
 SCHEDULE_EXPLORER_API_URL=http://localhost:8000

--- a/.env.example
+++ b/.env.example
@@ -24,6 +24,7 @@ MOBILITY_API_REFRESH_TOKEN=your-mobility-api-refresh-token-here
 # Le TEC uses Belgian Mobility APIM by default for static GTFS, GTFS-RT trip updates,
 # and GTFS-RT service alerts. The local provider id is "letec"; the APIM feed slug
 # remains "tec".
+# LETEC_APIM_FEED_SLUG=tec
 # LETEC_GTFS_STATIC_URL=https://api-management-opendata-production.azure-api.net/api/gtfs/feed/tec/static
 # LETEC_GTFS_RT_TRIP_UPDATES_URL=https://api-management-opendata-production.azure-api.net/api/gtfs/feed/tec/rt/trip-update
 # LETEC_GTFS_RT_SERVICE_ALERTS_URL=https://api-management-opendata-production.azure-api.net/api/gtfs/feed/tec/rt/alert

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,8 @@
 
 - Add a `letec` provider backed by Belgian Mobility APIM static GTFS, GTFS-RT trip updates, and GTFS-RT service alerts.
 - Keep Belgian Mobility's external `/tec/` feed slug configurable while exposing the local provider identity as `letec`; `tec` config/API aliases normalize to `letec`.
+- Normalize Belgian Mobility GTFS-RT ID prefixes and combine delay-only Le TEC trip updates with static `stop_times.txt` schedules so realtime waiting times populate from APIM feeds.
+- Keep default Le TEC static fallbacks HTTPS-only; the historical plaintext iRail fallback is no longer configured by default.
 - Document Le TEC API access, environment overrides, static fallback URLs, and the current NeTEx non-goal for this app.
 
 ## [v0.2.10](https://github.com/bdamokos/brussels_transit/tree/v0.2.10) (2026-06-21)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,14 @@
 
 # Changelog
 
+## Unreleased
+
+**Le TEC — Belgian Mobility Open Data (Azure APIM)**
+
+- Add a `letec` provider backed by Belgian Mobility APIM static GTFS, GTFS-RT trip updates, and GTFS-RT service alerts.
+- Keep Belgian Mobility's external `/tec/` feed slug configurable while exposing the local provider identity as `letec`; `tec` config/API aliases normalize to `letec`.
+- Document Le TEC API access, environment overrides, static fallback URLs, and the current NeTEx non-goal for this app.
+
 ## [v0.2.9](https://github.com/bdamokos/brussels_transit/tree/v0.2.9) (2026-06-21)
 
 [Full Changelog](https://github.com/bdamokos/brussels_transit/compare/v0.2.8...v0.2.9)

--- a/app/config/default.py
+++ b/app/config/default.py
@@ -34,6 +34,7 @@ def _parse_enabled_providers():
 
 # Provider Configuration
 ENABLED_PROVIDERS = _parse_enabled_providers()  # List of enabled transit providers
+LETEC_APIM_FEED_SLUG = os.getenv("LETEC_APIM_FEED_SLUG", "tec")
 
 # Language Configuration
 LANGUAGE_PRECEDENCE = ["en", "hu", "fr", "nl", "de"]  # Default language fallback chain
@@ -253,7 +254,7 @@ PROVIDER_CONFIG = {
     "letec": {
         "provider_specific": {
             "PROVIDER_ID": "f-u0g-tec",
-            "APIM_FEED_SLUG": os.getenv("LETEC_APIM_FEED_SLUG", "tec"),
+            "APIM_FEED_SLUG": LETEC_APIM_FEED_SLUG,
             "MOBILITY_API_PRIMARY_KEY": os.getenv("MOBILITY_API_PRIMARY_KEY"),
             "MOBILITY_API_SECONDARY_KEY": os.getenv("MOBILITY_API_SECONDARY_KEY"),
             "GTFS_STATIC_URL": os.getenv("LETEC_GTFS_STATIC_URL")
@@ -262,7 +263,7 @@ PROVIDER_CONFIG = {
                     "MOBILITY_APIM_BASE_URL",
                     "https://api-management-opendata-production.azure-api.net",
                 ).rstrip("/")
-                + "/api/gtfs/feed/tec/static"
+                + f"/api/gtfs/feed/{LETEC_APIM_FEED_SLUG}/static"
             ),
             "TRIP_UPDATES_URL": os.getenv("LETEC_GTFS_RT_TRIP_UPDATES_URL")
             or (
@@ -270,7 +271,7 @@ PROVIDER_CONFIG = {
                     "MOBILITY_APIM_BASE_URL",
                     "https://api-management-opendata-production.azure-api.net",
                 ).rstrip("/")
-                + "/api/gtfs/feed/tec/rt/trip-update"
+                + f"/api/gtfs/feed/{LETEC_APIM_FEED_SLUG}/rt/trip-update"
             ),
             "SERVICE_ALERTS_URL": os.getenv("LETEC_GTFS_RT_SERVICE_ALERTS_URL")
             or (
@@ -278,14 +279,13 @@ PROVIDER_CONFIG = {
                     "MOBILITY_APIM_BASE_URL",
                     "https://api-management-opendata-production.azure-api.net",
                 ).rstrip("/")
-                + "/api/gtfs/feed/tec/rt/alert"
+                + f"/api/gtfs/feed/{LETEC_APIM_FEED_SLUG}/rt/alert"
             ),
             "GTFS_STATIC_FALLBACK_URLS": [
                 os.getenv(
                     "LETEC_GTFS_STATIC_FALLBACK_URL",
                     "https://opendata.tec-wl.be/Current%20GTFS/TEC-GTFS.zip",
                 ),
-                "http://gtfs.irail.be/tec/tec-gtfs.zip",
             ],
             "GTFS_STATIC_DIR": CACHE_DIR / "letec/gtfs",
             "CACHE_DIR": CACHE_DIR / "letec",

--- a/app/config/default.py
+++ b/app/config/default.py
@@ -22,8 +22,14 @@ def _parse_enabled_providers():
             "stib",
             "bkk",
             "sncb",
+            "letec",
         ]
-    return [provider.strip() for provider in enabled.split(",") if provider.strip()]
+    aliases = {"tec": "letec"}
+    return [
+        aliases.get(provider.strip(), provider.strip())
+        for provider in enabled.split(",")
+        if provider.strip()
+    ]
 
 
 # Provider Configuration
@@ -243,5 +249,55 @@ PROVIDER_CONFIG = {
             },
         ],
         "monitored_lines": ["116", "117", "118", "144"],
+    },
+    "letec": {
+        "provider_specific": {
+            "PROVIDER_ID": "f-u0g-tec",
+            "APIM_FEED_SLUG": os.getenv("LETEC_APIM_FEED_SLUG", "tec"),
+            "MOBILITY_API_PRIMARY_KEY": os.getenv("MOBILITY_API_PRIMARY_KEY"),
+            "MOBILITY_API_SECONDARY_KEY": os.getenv("MOBILITY_API_SECONDARY_KEY"),
+            "GTFS_STATIC_URL": os.getenv("LETEC_GTFS_STATIC_URL")
+            or (
+                os.getenv(
+                    "MOBILITY_APIM_BASE_URL",
+                    "https://api-management-opendata-production.azure-api.net",
+                ).rstrip("/")
+                + "/api/gtfs/feed/tec/static"
+            ),
+            "TRIP_UPDATES_URL": os.getenv("LETEC_GTFS_RT_TRIP_UPDATES_URL")
+            or (
+                os.getenv(
+                    "MOBILITY_APIM_BASE_URL",
+                    "https://api-management-opendata-production.azure-api.net",
+                ).rstrip("/")
+                + "/api/gtfs/feed/tec/rt/trip-update"
+            ),
+            "SERVICE_ALERTS_URL": os.getenv("LETEC_GTFS_RT_SERVICE_ALERTS_URL")
+            or (
+                os.getenv(
+                    "MOBILITY_APIM_BASE_URL",
+                    "https://api-management-opendata-production.azure-api.net",
+                ).rstrip("/")
+                + "/api/gtfs/feed/tec/rt/alert"
+            ),
+            "GTFS_STATIC_FALLBACK_URLS": [
+                os.getenv(
+                    "LETEC_GTFS_STATIC_FALLBACK_URL",
+                    "https://opendata.tec-wl.be/Current%20GTFS/TEC-GTFS.zip",
+                ),
+                "http://gtfs.irail.be/tec/tec-gtfs.zip",
+            ],
+            "GTFS_STATIC_DIR": CACHE_DIR / "letec/gtfs",
+            "CACHE_DIR": CACHE_DIR / "letec",
+            "GTFS_CACHE_DURATION": 86400,
+            "GTFS_USED_FILES": [
+                "stops.txt",
+                "routes.txt",
+                "trips.txt",
+                "stop_times.txt",
+            ],
+        },
+        "stops": [],
+        "monitored_lines": [],
     },
 }

--- a/app/config/local.py.example
+++ b/app/config/local.py.example
@@ -41,7 +41,7 @@ TIMEZONE = "Europe/Brussels"
 
 
 # List of enabled providers
-ENABLED_PROVIDERS = ["delijn", "stib", "bkk"]
+ENABLED_PROVIDERS = ["delijn", "stib", "bkk", "sncb", "letec"]
 
 # Language Configuration
 # Override the default language precedence order
@@ -60,7 +60,11 @@ PROVIDER_CONFIG = {
         "MONITORED_LINES": [
             "3040",  # tram line 4
         ],
-    }
+    },
+    "letec": {
+        "STOP_IDS": [],
+        "MONITORED_LINES": [],
+    },
 }
 
 # Add any other overrides here

--- a/app/main.py
+++ b/app/main.py
@@ -846,9 +846,12 @@ async def provider_endpoint(provider, endpoint, param1=None, param2=None):
                 result = func()
 
         if original_provider != provider and isinstance(result, dict):
-            result.setdefault("_metadata", {})
-            result["_metadata"]["deprecated_provider"] = original_provider
-            result["_metadata"]["canonical_provider"] = provider
+            metadata = result.get("_metadata")
+            if not isinstance(metadata, dict):
+                metadata = {}
+                result["_metadata"] = metadata
+            metadata["deprecated_provider"] = original_provider
+            metadata["canonical_provider"] = provider
 
         return jsonify(result)
 

--- a/app/main.py
+++ b/app/main.py
@@ -22,6 +22,7 @@ import inspect
 import logging
 from flask import jsonify
 from transit_providers import PROVIDERS, get_provider_from_path
+from transit_providers.config import canonical_provider_name
 from config import get_config
 from dataclasses import asdict
 import os
@@ -743,6 +744,9 @@ async def provider_endpoint(provider, endpoint, param1=None, param2=None):
             # Redirect to the schedule explorer
             return redirect(url)
 
+        original_provider = provider
+        provider = canonical_provider_name(provider)
+
         # If not a proxied provider, check if it's a legacy provider
         if provider not in PROVIDERS:
             available_providers = list(PROVIDERS.keys())
@@ -840,6 +844,11 @@ async def provider_endpoint(provider, endpoint, param1=None, param2=None):
                 result = await func()
             else:
                 result = func()
+
+        if original_provider != provider and isinstance(result, dict):
+            result.setdefault("_metadata", {})
+            result["_metadata"]["deprecated_provider"] = original_provider
+            result["_metadata"]["canonical_provider"] = provider
 
         return jsonify(result)
 

--- a/app/transit_providers/__init__.py
+++ b/app/transit_providers/__init__.py
@@ -5,6 +5,7 @@ import importlib
 import logging
 from pathlib import Path
 import inspect
+from transit_providers.config import canonical_provider_name
 
 # Get logger
 logger = logging.getLogger(__name__)
@@ -59,6 +60,7 @@ def get_provider_path(provider_name: str) -> str:
 
 def register_provider(name: str, provider: Union[Dict[str, Callable], TransitProvider]) -> None:
     """Register a transit provider and its endpoints"""
+    name = canonical_provider_name(name)
     logger.debug(f"Registering provider: {name}")
     
     # If it's already a TransitProvider instance, store it directly
@@ -94,8 +96,11 @@ def import_providers():
     providers_dir = Path(__file__).parent
     from config import get_config
 
-    enabled_providers = set(get_config("ENABLED_PROVIDERS", []))
-    known_provider_packages = {"bkk", "delijn", "sncb", "stib"}
+    enabled_providers = {
+        canonical_provider_name(provider)
+        for provider in get_config("ENABLED_PROVIDERS", [])
+    }
+    known_provider_packages = {"bkk", "delijn", "letec", "sncb", "stib"}
     
     # Walk through all subdirectories
     for root, dirs, files in os.walk(providers_dir):

--- a/app/transit_providers/be/letec/__init__.py
+++ b/app/transit_providers/be/letec/__init__.py
@@ -1,0 +1,82 @@
+"""Le TEC transit provider."""
+
+from . import config  # noqa: F401
+
+import logging
+from pathlib import Path
+from typing import Any, Dict, List
+
+from config import get_config
+from transit_providers import PROVIDERS, TransitProvider, register_provider
+from transit_providers.config import canonical_provider_name, get_provider_config
+
+from .api import (
+    CACHE_DIR,
+    find_nearest_stops,
+    get_line_info,
+    get_service_alerts,
+    get_static_data,
+    get_stop_by_name,
+    get_waiting_times,
+    letec_config,
+)
+
+logger = logging.getLogger("letec")
+
+
+class LeTECProvider(TransitProvider):
+    """Le TEC transit provider."""
+
+    def __init__(self):
+        provider_config = get_provider_config("letec")
+        self.stop_ids = provider_config.get("STOP_IDS", [])
+        self.monitored_lines = provider_config.get("MONITORED_LINES", [])
+        self.cache_dir = Path(CACHE_DIR)
+        endpoints = {
+            "config": self.get_config,
+            "data": self.get_data,
+            "waiting_times": get_waiting_times,
+            "static_data": get_static_data,
+            "line_info": get_line_info,
+            "service_alerts": get_service_alerts,
+            "messages": get_service_alerts,
+            "get_nearest_stops": self.get_nearest_stops,
+            "get_stop_by_name": self.get_stop_by_name,
+        }
+        super().__init__(name="Le TEC", endpoints=endpoints)
+
+    async def get_config(self) -> Dict[str, Any]:
+        return await letec_config()
+
+    async def get_data(self) -> Dict[str, Any]:
+        return await get_waiting_times(self.stop_ids)
+
+    async def get_nearest_stops(
+        self, lat: float, lon: float, limit: int = 5, max_distance: float = 2.0
+    ) -> List[Dict[str, Any]]:
+        return await find_nearest_stops(lat, lon, limit, max_distance)
+
+    async def get_stop_by_name(self, name: str, limit: int = 5) -> List[Dict[str, Any]]:
+        return await get_stop_by_name(name, limit)
+
+
+enabled_providers = {
+    canonical_provider_name(provider)
+    for provider in get_config("ENABLED_PROVIDERS", [])
+}
+
+if "letec" in enabled_providers and "letec" not in PROVIDERS:
+    try:
+        register_provider("letec", LeTECProvider())
+        logger.info("Le TEC provider registered successfully")
+    except Exception as exc:
+        logger.error("Failed to register Le TEC provider: %s", exc, exc_info=True)
+
+
+__all__ = [
+    "LeTECProvider",
+    "get_waiting_times",
+    "get_static_data",
+    "get_line_info",
+    "get_service_alerts",
+]

--- a/app/transit_providers/be/letec/api.py
+++ b/app/transit_providers/be/letec/api.py
@@ -1,0 +1,681 @@
+"""Le TEC Belgian Mobility APIM provider."""
+
+import asyncio
+import csv
+import io
+import json
+import logging
+import shutil
+import time
+import zipfile
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional, Union
+from zoneinfo import ZoneInfo
+
+import httpx
+from google.protobuf import json_format
+
+from transit_providers.be.mobility import mobility_subscription_headers
+from google.transit import gtfs_realtime_pb2
+from transit_providers.config import get_provider_config
+from transit_providers.nearest_stop import (
+    Stop,
+    cache_stops,
+    get_cached_stops,
+    get_nearest_stops,
+    get_stop_by_name as generic_get_stop_by_name,
+    ingest_gtfs_stops,
+)
+
+logger = logging.getLogger("letec")
+
+PROVIDER = "letec"
+provider_config = get_provider_config(PROVIDER)
+
+CACHE_DIR = Path(provider_config.get("CACHE_DIR"))
+GTFS_STATIC_DIR = Path(provider_config.get("GTFS_STATIC_DIR"))
+GTFS_STATIC_METADATA_FILE = Path(provider_config.get("GTFS_STATIC_METADATA_FILE"))
+STOP_IDS = provider_config.get("STOP_IDS", [])
+MONITORED_LINES = provider_config.get("MONITORED_LINES", [])
+TRIP_UPDATES_URL = provider_config.get("TRIP_UPDATES_URL")
+SERVICE_ALERTS_URL = provider_config.get("SERVICE_ALERTS_URL")
+
+_stops_cache: Dict[str, Dict[str, Any]] = {}
+_routes_cache: Dict[str, Dict[str, Any]] = {}
+_trips_cache: Dict[str, Dict[str, Any]] = {}
+_stop_times_cache: Dict[str, List[Dict[str, Any]]] = {}
+_caches_initialized = False
+_init_lock: Optional[asyncio.Lock] = None
+_last_waiting_times_result: Optional[Dict[str, Any]] = None
+_last_waiting_times_update: Optional[float] = None
+_WAITING_TIMES_CACHE_DURATION = 2.0
+
+
+def _cache_duration_seconds() -> int:
+    duration = provider_config.get("GTFS_CACHE_DURATION", 86400)
+    if isinstance(duration, timedelta):
+        return int(duration.total_seconds())
+    return int(duration)
+
+
+def _required_gtfs_files() -> List[str]:
+    return ["stops.txt", "routes.txt", "trips.txt", "stop_times.txt"]
+
+
+def _gtfs_dir_has_required_files(path: Path) -> bool:
+    return path.exists() and all(
+        (path / filename).exists() for filename in _required_gtfs_files()
+    )
+
+
+def _safe_extract_zip(zf: zipfile.ZipFile, dest_dir: Path) -> None:
+    dest_root = dest_dir.resolve()
+    for member in zf.infolist():
+        name = member.filename
+        if not name or name.endswith("/"):
+            continue
+        target = (dest_root / name).resolve()
+        try:
+            target.relative_to(dest_root)
+        except ValueError:
+            logger.warning("Skipping ZIP entry outside GTFS dir: %s", name)
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with zf.open(member, "r") as src, open(target, "wb") as out_f:
+            shutil.copyfileobj(src, out_f)
+
+
+def _find_gtfs_root(path: Path) -> Path:
+    if _gtfs_dir_has_required_files(path):
+        return path
+    for child in path.rglob("stops.txt"):
+        candidate = child.parent
+        if _gtfs_dir_has_required_files(candidate):
+            return candidate
+    return path
+
+
+def _static_cache_is_valid() -> bool:
+    if not _gtfs_dir_has_required_files(GTFS_STATIC_DIR):
+        return False
+    if not GTFS_STATIC_METADATA_FILE.exists():
+        return False
+    try:
+        metadata = json.loads(GTFS_STATIC_METADATA_FILE.read_text(encoding="utf-8"))
+        downloaded_at = datetime.fromisoformat(metadata["downloaded_at"])
+        if downloaded_at.tzinfo is None:
+            downloaded_at = downloaded_at.replace(tzinfo=timezone.utc)
+    except (KeyError, ValueError, json.JSONDecodeError, OSError) as exc:
+        logger.warning("Ignoring invalid Le TEC GTFS metadata: %s", exc)
+        return False
+    return (
+        datetime.now(timezone.utc) - downloaded_at
+    ).total_seconds() < _cache_duration_seconds()
+
+
+async def _download_static_gtfs_from_url(
+    client: httpx.AsyncClient,
+    url: str,
+    headers: Optional[Dict[str, str]] = None,
+) -> Optional[Path]:
+    tmp_dir = GTFS_STATIC_DIR.parent / f".{GTFS_STATIC_DIR.name}.tmp"
+    if tmp_dir.exists():
+        shutil.rmtree(tmp_dir)
+    tmp_dir.mkdir(parents=True, exist_ok=True)
+
+    try:
+        response = await client.get(url, headers=headers)
+        response.raise_for_status()
+
+        with zipfile.ZipFile(io.BytesIO(response.content), "r") as zf:
+            _safe_extract_zip(zf, tmp_dir)
+
+        gtfs_root = _find_gtfs_root(tmp_dir)
+        if not _gtfs_dir_has_required_files(gtfs_root):
+            missing = [
+                filename
+                for filename in _required_gtfs_files()
+                if not (gtfs_root / filename).exists()
+            ]
+            logger.error("Le TEC GTFS download missing files: %s", missing)
+            shutil.rmtree(tmp_dir)
+            return None
+
+        if GTFS_STATIC_DIR.exists():
+            shutil.rmtree(GTFS_STATIC_DIR)
+        GTFS_STATIC_DIR.parent.mkdir(parents=True, exist_ok=True)
+        if gtfs_root == tmp_dir:
+            tmp_dir.rename(GTFS_STATIC_DIR)
+        else:
+            shutil.move(str(gtfs_root), str(GTFS_STATIC_DIR))
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+        GTFS_STATIC_METADATA_FILE.parent.mkdir(parents=True, exist_ok=True)
+        GTFS_STATIC_METADATA_FILE.write_text(
+            json.dumps(
+                {
+                    "downloaded_at": datetime.now(timezone.utc).isoformat(),
+                    "source_url": url,
+                    "last_modified": response.headers.get("last-modified"),
+                    "etag": response.headers.get("etag"),
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+        return GTFS_STATIC_DIR
+    except Exception as exc:
+        logger.error("Error downloading Le TEC GTFS from %s: %s", url, exc)
+        shutil.rmtree(tmp_dir, ignore_errors=True)
+        return None
+
+
+async def ensure_gtfs_data() -> Optional[Path]:
+    if _static_cache_is_valid():
+        return GTFS_STATIC_DIR
+
+    urls: List[tuple[str, Optional[Dict[str, str]]]] = []
+    if str(provider_config.get("GTFS_STATIC_SOURCE", "belgian_mobility")).lower() == (
+        "belgian_mobility"
+    ):
+        headers = mobility_subscription_headers(PROVIDER)
+        if headers and provider_config.get("GTFS_STATIC_URL"):
+            urls.append((provider_config["GTFS_STATIC_URL"], headers))
+        else:
+            logger.warning("Mobility APIM key not configured; using Le TEC static fallbacks")
+
+    urls.extend(
+        (url, None) for url in provider_config.get("GTFS_STATIC_FALLBACK_URLS", [])
+    )
+
+    timeout = httpx.Timeout(120.0, connect=10.0)
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+        for url, headers in urls:
+            path = await _download_static_gtfs_from_url(client, url, headers=headers)
+            if path:
+                return path
+    return None
+
+
+def _load_stops_cache() -> None:
+    global _stops_cache
+    stops_file = GTFS_STATIC_DIR / "stops.txt"
+    if not stops_file.exists():
+        return
+    new_cache: Dict[str, Dict[str, Any]] = {}
+    with open(stops_file, "r", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            stop_id = (row.get("stop_id") or "").strip()
+            if not stop_id:
+                continue
+            try:
+                new_cache[stop_id] = {
+                    "name": (row.get("stop_name") or stop_id).strip(),
+                    "lat": float(row["stop_lat"]) if row.get("stop_lat") else None,
+                    "lon": float(row["stop_lon"]) if row.get("stop_lon") else None,
+                }
+            except (KeyError, ValueError):
+                new_cache[stop_id] = {"name": stop_id, "lat": None, "lon": None}
+    _stops_cache = new_cache
+
+
+def _load_routes_cache() -> None:
+    global _routes_cache
+    routes_file = GTFS_STATIC_DIR / "routes.txt"
+    if not routes_file.exists():
+        return
+    new_cache: Dict[str, Dict[str, Any]] = {}
+    with open(routes_file, "r", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            route_id = (row.get("route_id") or "").strip()
+            if not route_id:
+                continue
+            route_type = row.get("route_type")
+            new_cache[route_id] = {
+                "route_id": route_id,
+                "route_short_name": (row.get("route_short_name") or route_id).strip(),
+                "route_long_name": (row.get("route_long_name") or "").strip(),
+                "route_desc": (row.get("route_desc") or "").strip(),
+                "route_type": int(route_type) if route_type else None,
+                "route_color": (row.get("route_color") or "").strip(),
+                "route_text_color": (row.get("route_text_color") or "").strip(),
+            }
+    _routes_cache = new_cache
+
+
+def _load_trips_cache() -> None:
+    global _trips_cache
+    trips_file = GTFS_STATIC_DIR / "trips.txt"
+    if not trips_file.exists():
+        return
+    new_cache: Dict[str, Dict[str, Any]] = {}
+    with open(trips_file, "r", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            trip_id = (row.get("trip_id") or "").strip()
+            if not trip_id:
+                continue
+            new_cache[trip_id] = {
+                "route_id": (row.get("route_id") or "").strip(),
+                "headsign": (row.get("trip_headsign") or "").strip(),
+            }
+    _trips_cache = new_cache
+
+
+def _load_stop_times_cache() -> None:
+    global _stop_times_cache
+    stop_times_file = GTFS_STATIC_DIR / "stop_times.txt"
+    if not stop_times_file.exists():
+        return
+    new_cache: Dict[str, List[Dict[str, Any]]] = {}
+    with open(stop_times_file, "r", encoding="utf-8-sig") as f:
+        reader = csv.DictReader(f)
+        for row in reader:
+            trip_id = (row.get("trip_id") or "").strip()
+            stop_id = (row.get("stop_id") or "").strip()
+            if not trip_id or not stop_id:
+                continue
+            try:
+                stop_sequence = int(row.get("stop_sequence") or 0)
+            except ValueError:
+                stop_sequence = 0
+            new_cache.setdefault(trip_id, []).append(
+                {"stop_id": stop_id, "stop_sequence": stop_sequence}
+            )
+    for stops in new_cache.values():
+        stops.sort(key=lambda stop: stop["stop_sequence"])
+    _stop_times_cache = new_cache
+
+
+async def _ensure_caches_initialized() -> None:
+    global _caches_initialized, _init_lock
+    if _caches_initialized:
+        return
+    if _init_lock is None:
+        _init_lock = asyncio.Lock()
+    async with _init_lock:
+        if _caches_initialized:
+            return
+        gtfs_path = await ensure_gtfs_data()
+        if not gtfs_path:
+            logger.error("Unable to initialize Le TEC caches without GTFS data")
+            return
+        _load_stops_cache()
+        _load_routes_cache()
+        _load_trips_cache()
+        _load_stop_times_cache()
+        _caches_initialized = True
+
+
+def _parse_realtime_feed(response: httpx.Response) -> gtfs_realtime_pb2.FeedMessage:
+    feed = gtfs_realtime_pb2.FeedMessage()
+    content_type = response.headers.get("content-type", "").lower()
+    if "json" in content_type:
+        json_format.ParseDict(
+            _unwrap_gtfs_json_ints(response.json()),
+            feed,
+            ignore_unknown_fields=True,
+        )
+    else:
+        feed.ParseFromString(response.content)
+    return feed
+
+
+def _unwrap_gtfs_json_ints(value: Any) -> Any:
+    """Convert protobufjs-style Long JSON objects into Python integers."""
+    if isinstance(value, dict):
+        if "low" in value and "high" in value:
+            low = int(value.get("low") or 0)
+            high = int(value.get("high") or 0)
+            return (high << 32) + (low & 0xFFFFFFFF)
+        return {key: _unwrap_gtfs_json_ints(val) for key, val in value.items()}
+    if isinstance(value, list):
+        return [_unwrap_gtfs_json_ints(item) for item in value]
+    return value
+
+
+async def _fetch_feed(url: str) -> gtfs_realtime_pb2.FeedMessage:
+    headers = mobility_subscription_headers(PROVIDER)
+    if not headers:
+        raise RuntimeError(
+            "MOBILITY_API_PRIMARY_KEY or MOBILITY_API_SECONDARY_KEY is required "
+            "for Le TEC Belgian Mobility realtime"
+        )
+    timeout = httpx.Timeout(20.0, connect=5.0)
+    async with httpx.AsyncClient(timeout=timeout, follow_redirects=True) as client:
+        response = await client.get(url, headers=headers)
+        response.raise_for_status()
+        return _parse_realtime_feed(response)
+
+
+def _trip_candidates(trip_id: str) -> Iterable[str]:
+    yield trip_id
+    if "-" in trip_id:
+        yield trip_id.split("-")[0]
+
+
+def _get_trip_info(trip_id: str) -> Dict[str, Any]:
+    for candidate in _trip_candidates(trip_id):
+        if candidate in _trips_cache:
+            return _trips_cache[candidate]
+    return {}
+
+
+def _get_stop_info(stop_id: str) -> Dict[str, Any]:
+    return _stops_cache.get(stop_id, {"name": f"Unknown stop ({stop_id})"})
+
+
+def _route_key(route_id: str) -> str:
+    route_info = _routes_cache.get(route_id, {})
+    return route_info.get("route_short_name") or route_id
+
+
+def _route_metadata(route_id: str) -> Dict[str, Any]:
+    route_info = _routes_cache.get(route_id, {})
+    metadata = {
+        "route_id": route_id,
+        "route_short_name": route_info.get("route_short_name", route_id),
+        "route_desc": route_info.get("route_desc", ""),
+        "route_long_name": route_info.get("route_long_name", ""),
+        "route_type": route_info.get("route_type"),
+    }
+    if route_info.get("route_color"):
+        metadata["color"] = f"#{route_info['route_color']}"
+    if route_info.get("route_text_color"):
+        metadata["text_color"] = f"#{route_info['route_text_color']}"
+    return metadata
+
+
+def _trip_route(trip_id: str) -> List[Dict[str, Any]]:
+    for candidate in _trip_candidates(trip_id):
+        stops = _stop_times_cache.get(candidate)
+        if stops:
+            return [
+                {
+                    "stop_id": stop["stop_id"],
+                    "stop_name": _get_stop_info(stop["stop_id"]).get(
+                        "name", stop["stop_id"]
+                    ),
+                    "stop_sequence": stop["stop_sequence"],
+                }
+                for stop in stops
+            ]
+    return []
+
+
+def _line_is_monitored(route_id: str, monitored_lines: List[str]) -> bool:
+    if not monitored_lines:
+        return True
+    route_info = _routes_cache.get(route_id, {})
+    candidates = {route_id, route_info.get("route_short_name")}
+    return any(line in candidates for line in monitored_lines)
+
+
+async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict[str, Any]:
+    await _ensure_caches_initialized()
+    global _last_waiting_times_result, _last_waiting_times_update
+
+    if isinstance(stop_id, str):
+        stop_ids = [s.strip() for s in stop_id.split(",") if s.strip()]
+    elif stop_id:
+        stop_ids = [str(s) for s in stop_id]
+    else:
+        stop_ids = [str(s) for s in get_provider_config(PROVIDER).get("STOP_IDS", [])]
+
+    monitored_lines = get_provider_config(PROVIDER).get("MONITORED_LINES", [])
+    formatted_data = {
+        "stops_data": {
+            sid: {
+                "name": _get_stop_info(sid).get("name", f"Unknown stop ({sid})"),
+                "coordinates": (
+                    {
+                        "lat": _get_stop_info(sid).get("lat"),
+                        "lon": _get_stop_info(sid).get("lon"),
+                    }
+                    if _get_stop_info(sid).get("lat") and _get_stop_info(sid).get("lon")
+                    else None
+                ),
+                "lines": {},
+            }
+            for sid in stop_ids
+        },
+        "_metadata": {"provider": PROVIDER, "realtime_source": "belgian_mobility"},
+    }
+    if not stop_ids:
+        return formatted_data
+
+    now = time.time()
+    if (
+        _last_waiting_times_result
+        and _last_waiting_times_update
+        and now - _last_waiting_times_update < _WAITING_TIMES_CACHE_DURATION
+        and all(sid in _last_waiting_times_result["stops_data"] for sid in stop_ids)
+    ):
+        return _last_waiting_times_result
+
+    try:
+        if not TRIP_UPDATES_URL:
+            raise RuntimeError("LETEC_GTFS_RT_TRIP_UPDATES_URL is not configured")
+        feed = await _fetch_feed(TRIP_UPDATES_URL)
+        now_local = datetime.now(timezone.utc).astimezone(ZoneInfo("Europe/Brussels"))
+
+        for entity in feed.entity:
+            if not entity.HasField("trip_update"):
+                continue
+            update = entity.trip_update
+            trip_id = update.trip.trip_id
+            trip_info = _get_trip_info(trip_id)
+            route_id = update.trip.route_id or trip_info.get("route_id")
+            if not route_id or not _line_is_monitored(route_id, monitored_lines):
+                continue
+
+            route_stops = _trip_route(trip_id)
+            destination = (
+                trip_info.get("headsign")
+                or (route_stops[-1]["stop_name"] if route_stops else "")
+                or route_id
+            )
+            line_key = _route_key(route_id)
+            route_metadata = _route_metadata(route_id)
+
+            for stop_time in update.stop_time_update:
+                sid = stop_time.stop_id
+                if sid not in formatted_data["stops_data"]:
+                    continue
+
+                event = (
+                    stop_time.arrival
+                    if stop_time.HasField("arrival")
+                    else stop_time.departure
+                    if stop_time.HasField("departure")
+                    else None
+                )
+                if event is None or not event.time:
+                    continue
+
+                line_data = formatted_data["stops_data"][sid]["lines"].setdefault(
+                    line_key, {"_metadata": route_metadata}
+                )
+                times = line_data.setdefault(destination, [])
+                arrival_time = datetime.fromtimestamp(event.time, timezone.utc).astimezone(
+                    ZoneInfo("Europe/Brussels")
+                )
+                minutes = int((arrival_time - now_local).total_seconds() / 60)
+                if minutes < -2:
+                    continue
+
+                delay = event.delay if event.HasField("delay") else None
+                current_sequence = next(
+                    (
+                        stop["stop_sequence"]
+                        for stop in route_stops
+                        if stop["stop_id"] == sid
+                    ),
+                    None,
+                )
+                remaining_stops = [
+                    stop["stop_name"]
+                    for stop in route_stops
+                    if current_sequence is not None
+                    and stop["stop_sequence"] > current_sequence
+                ]
+                times.append(
+                    {
+                        "delay": delay,
+                        "is_realtime": delay is not None,
+                        "message": None,
+                        "realtime_minutes": f"{minutes}'",
+                        "realtime_time": arrival_time.strftime("%H:%M"),
+                        "provider": PROVIDER,
+                        "remaining_stops": remaining_stops,
+                    }
+                )
+
+        for stop_data in formatted_data["stops_data"].values():
+            empty_lines = []
+            for line_id, line_data in stop_data["lines"].items():
+                for destination, times in list(line_data.items()):
+                    if destination == "_metadata":
+                        continue
+                    times.sort(key=lambda item: item["realtime_time"])
+                    if not times:
+                        del line_data[destination]
+                if len(line_data) == 1 and "_metadata" in line_data:
+                    empty_lines.append(line_id)
+            for line_id in empty_lines:
+                del stop_data["lines"][line_id]
+
+        _last_waiting_times_result = formatted_data
+        _last_waiting_times_update = time.time()
+        return formatted_data
+    except Exception as exc:
+        logger.error("Error getting Le TEC waiting times: %s", exc)
+        formatted_data["_metadata"]["error"] = str(exc)
+        return formatted_data
+
+
+def _translated_text(translated_string) -> Dict[str, str]:
+    return {
+        translation.language or "und": translation.text
+        for translation in translated_string.translation
+    }
+
+
+def _enum_name(enum_type, value: int) -> str:
+    try:
+        return enum_type.Name(value)
+    except ValueError:
+        return str(value)
+
+
+async def get_service_alerts() -> List[Dict[str, Any]]:
+    if not SERVICE_ALERTS_URL:
+        return []
+    try:
+        feed = await _fetch_feed(SERVICE_ALERTS_URL)
+    except Exception as exc:
+        logger.error("Error getting Le TEC service alerts: %s", exc)
+        return []
+
+    alerts: List[Dict[str, Any]] = []
+    for entity in feed.entity:
+        if not entity.HasField("alert"):
+            continue
+        alert = entity.alert
+        alerts.append(
+            {
+                "id": entity.id,
+                "provider": PROVIDER,
+                "cause": _enum_name(gtfs_realtime_pb2.Alert.Cause, alert.cause),
+                "effect": _enum_name(gtfs_realtime_pb2.Alert.Effect, alert.effect),
+                "header": _translated_text(alert.header_text),
+                "description": _translated_text(alert.description_text),
+                "url": _translated_text(alert.url),
+                "active_periods": [
+                    {
+                        "start": period.start if period.start else None,
+                        "end": period.end if period.end else None,
+                    }
+                    for period in alert.active_period
+                ],
+                "informed_entities": [
+                    {
+                        "agency_id": entity_selector.agency_id or None,
+                        "route_id": entity_selector.route_id or None,
+                        "stop_id": entity_selector.stop_id or None,
+                    }
+                    for entity_selector in alert.informed_entity
+                ],
+            }
+        )
+    return alerts
+
+
+async def get_static_data() -> Dict[str, Any]:
+    await _ensure_caches_initialized()
+    return {"provider": PROVIDER, "line_info": await get_line_info()}
+
+
+async def letec_config() -> Dict[str, Any]:
+    return {
+        "name": "Le TEC",
+        "city": "Wallonia",
+        "country": "Belgium",
+        "monitored_lines": get_provider_config(PROVIDER).get("MONITORED_LINES", []),
+        "stop_ids": get_provider_config(PROVIDER).get("STOP_IDS", []),
+        "capabilities": {
+            "has_vehicle_positions": False,
+            "has_waiting_times": True,
+            "has_service_alerts": True,
+            "has_line_info": True,
+            "has_route_shapes": False,
+            "has_netex": False,
+        },
+    }
+
+
+async def get_line_info() -> Dict[str, Dict[str, Any]]:
+    await _ensure_caches_initialized()
+    monitored_lines = get_provider_config(PROVIDER).get("MONITORED_LINES", [])
+    result = {}
+    for route_id, route_info in _routes_cache.items():
+        if not _line_is_monitored(route_id, monitored_lines):
+            continue
+        line_key = _route_key(route_id)
+        metadata = _route_metadata(route_id)
+        result[line_key] = {
+            "route_id": route_id,
+            "display_name": line_key,
+            "provider": PROVIDER,
+            **metadata,
+        }
+    return result
+
+
+async def get_stops() -> Dict[str, Stop]:
+    await _ensure_caches_initialized()
+    cache_path = CACHE_DIR / "stops.json"
+    cached_stops = get_cached_stops(cache_path)
+    if cached_stops:
+        return cached_stops
+    stops = ingest_gtfs_stops(GTFS_STATIC_DIR)
+    if stops:
+        cache_stops(stops, cache_path)
+    return stops
+
+
+async def find_nearest_stops(
+    lat: float, lon: float, limit: int = 5, max_distance: float = 2.0
+) -> List[Dict[str, Any]]:
+    stops = await get_stops()
+    nearest = get_nearest_stops(stops, lat, lon, limit, max_distance)
+    return [stop.__dict__ for stop in nearest]
+
+
+async def get_stop_by_name(name: str, limit: int = 5) -> List[Dict[str, Any]]:
+    stops = await get_stops()
+    matches = generic_get_stop_by_name(stops, name, limit)
+    return [stop.__dict__ for stop in matches] if matches else []

--- a/app/transit_providers/be/letec/api.py
+++ b/app/transit_providers/be/letec/api.py
@@ -239,11 +239,21 @@ def _load_routes_cache() -> None:
                 "route_short_name": (row.get("route_short_name") or route_id).strip(),
                 "route_long_name": (row.get("route_long_name") or "").strip(),
                 "route_desc": (row.get("route_desc") or "").strip(),
-                "route_type": int(route_type) if route_type else None,
+                "route_type": _parse_route_type(route_type),
                 "route_color": (row.get("route_color") or "").strip(),
                 "route_text_color": (row.get("route_text_color") or "").strip(),
             }
     _routes_cache = new_cache
+
+
+def _parse_route_type(route_type: Optional[str]) -> Optional[int]:
+    if not route_type or not route_type.strip():
+        return None
+    try:
+        return int(route_type)
+    except ValueError:
+        logger.warning("Ignoring invalid Le TEC GTFS route_type: %s", route_type)
+        return None
 
 
 def _load_trips_cache() -> None:
@@ -283,7 +293,12 @@ def _load_stop_times_cache() -> None:
             except ValueError:
                 stop_sequence = 0
             new_cache.setdefault(trip_id, []).append(
-                {"stop_id": stop_id, "stop_sequence": stop_sequence}
+                {
+                    "stop_id": stop_id,
+                    "stop_sequence": stop_sequence,
+                    "arrival_time": (row.get("arrival_time") or "").strip(),
+                    "departure_time": (row.get("departure_time") or "").strip(),
+                }
             )
     for stops in new_cache.values():
         stops.sort(key=lambda stop: stop["stop_sequence"])
@@ -324,6 +339,58 @@ def _parse_realtime_feed(response: httpx.Response) -> gtfs_realtime_pb2.FeedMess
     return feed
 
 
+def _normalize_gtfs_id(value: Optional[str]) -> str:
+    if not value:
+        return ""
+    parts = value.split(":", 2)
+    if len(parts) == 3 and parts[1] == provider_config.get("APIM_FEED_SLUG", "tec"):
+        return parts[2]
+    return value
+
+
+def _parse_gtfs_datetime(
+    service_date: Optional[str], gtfs_time: Optional[str]
+) -> Optional[datetime]:
+    if not gtfs_time:
+        return None
+    try:
+        hours, minutes, seconds = [int(part) for part in gtfs_time.split(":")]
+    except (TypeError, ValueError):
+        return None
+
+    timezone_brussels = ZoneInfo("Europe/Brussels")
+    if service_date:
+        try:
+            service_day = datetime.strptime(service_date, "%Y%m%d").date()
+        except ValueError:
+            service_day = datetime.now(timezone_brussels).date()
+    else:
+        service_day = datetime.now(timezone_brussels).date()
+
+    base = datetime.combine(service_day, datetime.min.time(), tzinfo=timezone_brussels)
+    return base + timedelta(hours=hours, minutes=minutes, seconds=seconds)
+
+
+def _scheduled_stop_time(
+    trip_id: str,
+    stop_id: str,
+    stop_sequence: Optional[int],
+    service_date: Optional[str],
+    use_arrival: bool,
+) -> Optional[datetime]:
+    time_key = "arrival_time" if use_arrival else "departure_time"
+    fallback_key = "departure_time" if use_arrival else "arrival_time"
+    for stop in _trip_route_entries(trip_id):
+        if stop["stop_id"] != stop_id:
+            continue
+        if stop_sequence is not None and stop["stop_sequence"] != stop_sequence:
+            continue
+        return _parse_gtfs_datetime(
+            service_date, stop.get(time_key) or stop.get(fallback_key)
+        )
+    return None
+
+
 def _unwrap_gtfs_json_ints(value: Any) -> Any:
     """Convert protobufjs-style Long JSON objects into Python integers."""
     if isinstance(value, dict):
@@ -352,6 +419,7 @@ async def _fetch_feed(url: str) -> gtfs_realtime_pb2.FeedMessage:
 
 
 def _trip_candidates(trip_id: str) -> Iterable[str]:
+    trip_id = _normalize_gtfs_id(trip_id)
     yield trip_id
     if "-" in trip_id:
         yield trip_id.split("-")[0]
@@ -365,15 +433,18 @@ def _get_trip_info(trip_id: str) -> Dict[str, Any]:
 
 
 def _get_stop_info(stop_id: str) -> Dict[str, Any]:
+    stop_id = _normalize_gtfs_id(stop_id)
     return _stops_cache.get(stop_id, {"name": f"Unknown stop ({stop_id})"})
 
 
 def _route_key(route_id: str) -> str:
+    route_id = _normalize_gtfs_id(route_id)
     route_info = _routes_cache.get(route_id, {})
     return route_info.get("route_short_name") or route_id
 
 
 def _route_metadata(route_id: str) -> Dict[str, Any]:
+    route_id = _normalize_gtfs_id(route_id)
     route_info = _routes_cache.get(route_id, {})
     metadata = {
         "route_id": route_id,
@@ -390,23 +461,26 @@ def _route_metadata(route_id: str) -> Dict[str, Any]:
 
 
 def _trip_route(trip_id: str) -> List[Dict[str, Any]]:
+    return [
+        {
+            "stop_id": stop["stop_id"],
+            "stop_name": _get_stop_info(stop["stop_id"]).get("name", stop["stop_id"]),
+            "stop_sequence": stop["stop_sequence"],
+        }
+        for stop in _trip_route_entries(trip_id)
+    ]
+
+
+def _trip_route_entries(trip_id: str) -> List[Dict[str, Any]]:
     for candidate in _trip_candidates(trip_id):
         stops = _stop_times_cache.get(candidate)
         if stops:
-            return [
-                {
-                    "stop_id": stop["stop_id"],
-                    "stop_name": _get_stop_info(stop["stop_id"]).get(
-                        "name", stop["stop_id"]
-                    ),
-                    "stop_sequence": stop["stop_sequence"],
-                }
-                for stop in stops
-            ]
+            return stops
     return []
 
 
 def _line_is_monitored(route_id: str, monitored_lines: List[str]) -> bool:
+    route_id = _normalize_gtfs_id(route_id)
     if not monitored_lines:
         return True
     route_info = _routes_cache.get(route_id, {})
@@ -419,11 +493,16 @@ async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict[str, 
     global _last_waiting_times_result, _last_waiting_times_update
 
     if isinstance(stop_id, str):
-        stop_ids = [s.strip() for s in stop_id.split(",") if s.strip()]
+        stop_ids = [
+            _normalize_gtfs_id(s.strip()) for s in stop_id.split(",") if s.strip()
+        ]
     elif stop_id:
-        stop_ids = [str(s) for s in stop_id]
+        stop_ids = [_normalize_gtfs_id(str(s)) for s in stop_id]
     else:
-        stop_ids = [str(s) for s in get_provider_config(PROVIDER).get("STOP_IDS", [])]
+        stop_ids = [
+            _normalize_gtfs_id(str(s))
+            for s in get_provider_config(PROVIDER).get("STOP_IDS", [])
+        ]
 
     monitored_lines = get_provider_config(PROVIDER).get("MONITORED_LINES", [])
     formatted_data = {
@@ -466,9 +545,11 @@ async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict[str, 
             if not entity.HasField("trip_update"):
                 continue
             update = entity.trip_update
-            trip_id = update.trip.trip_id
+            trip_id = _normalize_gtfs_id(update.trip.trip_id)
             trip_info = _get_trip_info(trip_id)
-            route_id = update.trip.route_id or trip_info.get("route_id")
+            route_id = _normalize_gtfs_id(update.trip.route_id) or trip_info.get(
+                "route_id"
+            )
             if not route_id or not _line_is_monitored(route_id, monitored_lines):
                 continue
 
@@ -482,32 +563,51 @@ async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict[str, 
             route_metadata = _route_metadata(route_id)
 
             for stop_time in update.stop_time_update:
-                sid = stop_time.stop_id
+                sid = _normalize_gtfs_id(stop_time.stop_id)
                 if sid not in formatted_data["stops_data"]:
                     continue
 
+                has_arrival = stop_time.HasField("arrival")
                 event = (
                     stop_time.arrival
-                    if stop_time.HasField("arrival")
+                    if has_arrival
                     else stop_time.departure
                     if stop_time.HasField("departure")
                     else None
                 )
-                if event is None or not event.time:
+                if event is None:
                     continue
+                delay = event.delay if event.HasField("delay") else None
+                if event.HasField("time"):
+                    event_timestamp = event.time
+                else:
+                    stop_sequence = (
+                        int(stop_time.stop_sequence)
+                        if stop_time.HasField("stop_sequence")
+                        else None
+                    )
+                    scheduled_time = _scheduled_stop_time(
+                        trip_id,
+                        sid,
+                        stop_sequence,
+                        update.trip.start_date,
+                        has_arrival,
+                    )
+                    if scheduled_time is None:
+                        continue
+                    event_timestamp = int(scheduled_time.timestamp()) + (delay or 0)
 
                 line_data = formatted_data["stops_data"][sid]["lines"].setdefault(
                     line_key, {"_metadata": route_metadata}
                 )
                 times = line_data.setdefault(destination, [])
-                arrival_time = datetime.fromtimestamp(event.time, timezone.utc).astimezone(
-                    ZoneInfo("Europe/Brussels")
-                )
+                arrival_time = datetime.fromtimestamp(
+                    event_timestamp, timezone.utc
+                ).astimezone(ZoneInfo("Europe/Brussels"))
                 minutes = int((arrival_time - now_local).total_seconds() / 60)
                 if minutes < -2:
                     continue
 
-                delay = event.delay if event.HasField("delay") else None
                 current_sequence = next(
                     (
                         stop["stop_sequence"]
@@ -529,6 +629,7 @@ async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict[str, 
                         "message": None,
                         "realtime_minutes": f"{minutes}'",
                         "realtime_time": arrival_time.strftime("%H:%M"),
+                        "timestamp": event_timestamp,
                         "provider": PROVIDER,
                         "remaining_stops": remaining_stops,
                     }
@@ -540,7 +641,7 @@ async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict[str, 
                 for destination, times in list(line_data.items()):
                     if destination == "_metadata":
                         continue
-                    times.sort(key=lambda item: item["realtime_time"])
+                    times.sort(key=lambda item: item["timestamp"])
                     if not times:
                         del line_data[destination]
                 if len(line_data) == 1 and "_metadata" in line_data:
@@ -604,8 +705,9 @@ async def get_service_alerts() -> List[Dict[str, Any]]:
                 "informed_entities": [
                     {
                         "agency_id": entity_selector.agency_id or None,
-                        "route_id": entity_selector.route_id or None,
-                        "stop_id": entity_selector.stop_id or None,
+                        "route_id": _normalize_gtfs_id(entity_selector.route_id)
+                        or None,
+                        "stop_id": _normalize_gtfs_id(entity_selector.stop_id) or None,
                     }
                     for entity_selector in alert.informed_entity
                 ],

--- a/app/transit_providers/be/letec/api.py
+++ b/app/transit_providers/be/letec/api.py
@@ -49,6 +49,7 @@ _caches_initialized = False
 _init_lock: Optional[asyncio.Lock] = None
 _last_waiting_times_result: Optional[Dict[str, Any]] = None
 _last_waiting_times_update: Optional[float] = None
+_last_waiting_times_key: Optional[tuple[str, ...]] = None
 _WAITING_TIMES_CACHE_DURATION = 2.0
 
 
@@ -142,14 +143,28 @@ async def _download_static_gtfs_from_url(
             shutil.rmtree(tmp_dir)
             return None
 
-        if GTFS_STATIC_DIR.exists():
-            shutil.rmtree(GTFS_STATIC_DIR)
         GTFS_STATIC_DIR.parent.mkdir(parents=True, exist_ok=True)
+        new_dir = GTFS_STATIC_DIR.parent / f".{GTFS_STATIC_DIR.name}.new"
+        if new_dir.exists():
+            shutil.rmtree(new_dir, ignore_errors=True)
         if gtfs_root == tmp_dir:
-            tmp_dir.rename(GTFS_STATIC_DIR)
+            tmp_dir.rename(new_dir)
         else:
-            shutil.move(str(gtfs_root), str(GTFS_STATIC_DIR))
+            shutil.move(str(gtfs_root), str(new_dir))
             shutil.rmtree(tmp_dir, ignore_errors=True)
+
+        backup_dir = GTFS_STATIC_DIR.parent / f".{GTFS_STATIC_DIR.name}.bak"
+        if backup_dir.exists():
+            shutil.rmtree(backup_dir, ignore_errors=True)
+        if GTFS_STATIC_DIR.exists():
+            GTFS_STATIC_DIR.rename(backup_dir)
+        try:
+            new_dir.rename(GTFS_STATIC_DIR)
+            shutil.rmtree(backup_dir, ignore_errors=True)
+        except Exception:
+            if backup_dir.exists() and not GTFS_STATIC_DIR.exists():
+                backup_dir.rename(GTFS_STATIC_DIR)
+            raise
 
         GTFS_STATIC_METADATA_FILE.parent.mkdir(parents=True, exist_ok=True)
         GTFS_STATIC_METADATA_FILE.write_text(
@@ -491,6 +506,7 @@ def _line_is_monitored(route_id: str, monitored_lines: List[str]) -> bool:
 async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict[str, Any]:
     await _ensure_caches_initialized()
     global _last_waiting_times_result, _last_waiting_times_update
+    global _last_waiting_times_key
 
     if isinstance(stop_id, str):
         stop_ids = [
@@ -526,12 +542,13 @@ async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict[str, 
     if not stop_ids:
         return formatted_data
 
+    cache_key = tuple(sorted(stop_ids))
     now = time.time()
     if (
         _last_waiting_times_result
         and _last_waiting_times_update
         and now - _last_waiting_times_update < _WAITING_TIMES_CACHE_DURATION
-        and all(sid in _last_waiting_times_result["stops_data"] for sid in stop_ids)
+        and _last_waiting_times_key == cache_key
     ):
         return _last_waiting_times_result
 
@@ -651,6 +668,7 @@ async def get_waiting_times(stop_id: Union[str, List[str]] = None) -> Dict[str, 
 
         _last_waiting_times_result = formatted_data
         _last_waiting_times_update = time.time()
+        _last_waiting_times_key = cache_key
         return formatted_data
     except Exception as exc:
         logger.error("Error getting Le TEC waiting times: %s", exc)

--- a/app/transit_providers/be/letec/config.py
+++ b/app/transit_providers/be/letec/config.py
@@ -27,7 +27,6 @@ DEFAULT_CONFIG = {
         for url in [
             os.getenv("LETEC_GTFS_STATIC_FALLBACK_URL"),
             "https://opendata.tec-wl.be/Current%20GTFS/TEC-GTFS.zip",
-            "http://gtfs.irail.be/tec/tec-gtfs.zip",
         ]
         if url
     ],

--- a/app/transit_providers/be/letec/config.py
+++ b/app/transit_providers/be/letec/config.py
@@ -1,0 +1,52 @@
+"""Le TEC transit provider configuration."""
+
+import os
+from pathlib import Path
+
+from transit_providers.be.mobility import mobility_url
+from transit_providers.config import register_provider_config
+
+PROJECT_ROOT = Path(os.environ["PROJECT_ROOT"])
+LETEC_CACHE_DIR = PROJECT_ROOT / "cache" / "letec"
+
+APIM_FEED_SLUG = os.getenv("LETEC_APIM_FEED_SLUG", "tec")
+
+DEFAULT_CONFIG = {
+    "PROVIDER_ID": "f-u0g-tec",
+    "APIM_FEED_SLUG": APIM_FEED_SLUG,
+    "MOBILITY_API_PRIMARY_KEY": os.getenv("MOBILITY_API_PRIMARY_KEY"),
+    "MOBILITY_API_SECONDARY_KEY": os.getenv("MOBILITY_API_SECONDARY_KEY"),
+    "CACHE_DIR": LETEC_CACHE_DIR,
+    "GTFS_STATIC_SOURCE": os.getenv("LETEC_GTFS_STATIC_SOURCE", "belgian_mobility"),
+    "GTFS_STATIC_URL": os.getenv(
+        "LETEC_GTFS_STATIC_URL",
+        mobility_url(f"/api/gtfs/feed/{APIM_FEED_SLUG}/static"),
+    ),
+    "GTFS_STATIC_FALLBACK_URLS": [
+        url
+        for url in [
+            os.getenv("LETEC_GTFS_STATIC_FALLBACK_URL"),
+            "https://opendata.tec-wl.be/Current%20GTFS/TEC-GTFS.zip",
+            "http://gtfs.irail.be/tec/tec-gtfs.zip",
+        ]
+        if url
+    ],
+    "GTFS_STATIC_DIR": LETEC_CACHE_DIR / "gtfs",
+    "GTFS_STATIC_METADATA_FILE": LETEC_CACHE_DIR / "gtfs" / "metadata.json",
+    "GTFS_USED_FILES": ["stops.txt", "routes.txt", "trips.txt", "stop_times.txt"],
+    "GTFS_CACHE_DURATION": 86400,
+    "REALTIME_SOURCE": os.getenv("LETEC_REALTIME_SOURCE", "belgian_mobility"),
+    "TRIP_UPDATES_URL": os.getenv(
+        "LETEC_GTFS_RT_TRIP_UPDATES_URL",
+        mobility_url(f"/api/gtfs/feed/{APIM_FEED_SLUG}/rt/trip-update"),
+    ),
+    "SERVICE_ALERTS_URL": os.getenv(
+        "LETEC_GTFS_RT_SERVICE_ALERTS_URL",
+        mobility_url(f"/api/gtfs/feed/{APIM_FEED_SLUG}/rt/alert"),
+    ),
+    "STOP_IDS": [],
+    "MONITORED_LINES": [],
+    "RATE_LIMIT_DELAY": 0.5,
+}
+
+register_provider_config("letec", DEFAULT_CONFIG)

--- a/app/transit_providers/be/letec/readme.md
+++ b/app/transit_providers/be/letec/readme.md
@@ -1,0 +1,26 @@
+# Le TEC
+
+Le TEC publishes open static and realtime public transport data through the
+Belgian Mobility Open Data Portal.
+
+The provider uses Belgian Mobility APIM by default:
+
+- Static GTFS: `/api/gtfs/feed/tec/static`
+- GTFS-RT trip updates: `/api/gtfs/feed/tec/rt/trip-update`
+- GTFS-RT service alerts: `/api/gtfs/feed/tec/rt/alert`
+
+The local provider ID is `letec`. The Belgian Mobility APIM feed slug remains
+`tec`, so endpoint overrides keep the `LETEC_` prefix while default URLs contain
+`/tec/`.
+
+Set `MOBILITY_API_PRIMARY_KEY` or `MOBILITY_API_SECONDARY_KEY` in `.env`. The
+app sends the key as both `Ocp-Apim-Subscription-Key` and `bmc-partner-key` for
+compatibility with Belgian Mobility APIM products.
+
+Static GTFS falls back to the historical Le TEC static ZIPs when APIM static
+GTFS is unavailable. Realtime fallbacks are not configured; the legacy Le TEC
+realtime APIs are not wired into this app.
+
+NeTEx data is available in the Belgian Mobility ecosystem, but this provider
+does not consume NeTEx yet because the app's realtime display and stop explorer
+are GTFS/GTFS-RT based.

--- a/app/transit_providers/be/letec/readme.md
+++ b/app/transit_providers/be/letec/readme.md
@@ -17,7 +17,17 @@ Set `MOBILITY_API_PRIMARY_KEY` or `MOBILITY_API_SECONDARY_KEY` in `.env`. The
 app sends the key as both `Ocp-Apim-Subscription-Key` and `bmc-partner-key` for
 compatibility with Belgian Mobility APIM products.
 
-Static GTFS falls back to the historical Le TEC static ZIPs when APIM static
+Belgian Mobility GTFS-RT IDs are normalized before joining to static GTFS:
+
+- `gs:tec:*` stop IDs map to static `stop_id`
+- `gr:tec:*` route IDs map to static `route_id`
+- `gt:tec:*` trip IDs map to static `trip_id`
+
+Le TEC trip updates may provide stop-level delays without absolute event times.
+When that happens, the provider combines the GTFS-RT delay with the static
+`stop_times.txt` schedule for the matching trip/stop/sequence.
+
+Static GTFS falls back to the official HTTPS Le TEC static ZIP when APIM static
 GTFS is unavailable. Realtime fallbacks are not configured; the legacy Le TEC
 realtime APIs are not wired into this app.
 

--- a/app/transit_providers/be/letec/test_letec.py
+++ b/app/transit_providers/be/letec/test_letec.py
@@ -1,5 +1,6 @@
 import asyncio
 from datetime import datetime, timedelta, timezone
+from zoneinfo import ZoneInfo
 
 import httpx
 
@@ -28,15 +29,30 @@ def test_parse_realtime_feed_accepts_binary_protobuf():
     assert parsed.entity[0].trip_update.trip.trip_id == "t1"
 
 
+def test_parse_route_type_handles_invalid_values():
+    assert api._parse_route_type("3") == 3
+    assert api._parse_route_type(" 3 ") == 3
+    assert api._parse_route_type("") is None
+    assert api._parse_route_type("not-a-number") is None
+
+
+def test_normalize_gtfs_id_strips_belgian_mobility_prefixes():
+    assert api._normalize_gtfs_id("gs:tec:stop-1") == "stop-1"
+    assert api._normalize_gtfs_id("gr:tec:route-1") == "route-1"
+    assert api._normalize_gtfs_id("gt:tec:trip-1") == "trip-1"
+    assert api._normalize_gtfs_id("stop-1") == "stop-1"
+    assert api._normalize_gtfs_id(None) == ""
+
+
 def test_get_waiting_times_formats_trip_updates(monkeypatch):
     now = datetime.now(timezone.utc)
     feed = gtfs_realtime_pb2.FeedMessage()
     feed.header.gtfs_realtime_version = "2.0"
     entity = feed.entity.add(id="e1")
-    entity.trip_update.trip.trip_id = "trip-1"
-    entity.trip_update.trip.route_id = "route-1"
+    entity.trip_update.trip.trip_id = "gt:tec:trip-1"
+    entity.trip_update.trip.route_id = "gr:tec:route-1"
     stop_update = entity.trip_update.stop_time_update.add()
-    stop_update.stop_id = "stop-1"
+    stop_update.stop_id = "gs:tec:stop-1"
     stop_update.arrival.time = int((now + timedelta(minutes=5)).timestamp())
     stop_update.arrival.delay = 60
 
@@ -84,13 +100,142 @@ def test_get_waiting_times_formats_trip_updates(monkeypatch):
         },
     )
 
-    result = asyncio.run(api.get_waiting_times("stop-1"))
+    result = asyncio.run(api.get_waiting_times("gs:tec:stop-1"))
 
     line = result["stops_data"]["stop-1"]["lines"]["12"]
     assert line["_metadata"]["route_id"] == "route-1"
     assert line["Jambes"][0]["provider"] == "letec"
     assert line["Jambes"][0]["delay"] == 60
     assert line["Jambes"][0]["is_realtime"] is True
+    assert line["Jambes"][0]["timestamp"] == stop_update.arrival.time
+
+
+def test_get_waiting_times_sorts_by_timestamp_across_midnight(monkeypatch):
+    local_now = datetime.now(ZoneInfo("Europe/Brussels"))
+    first_arrival = local_now.replace(hour=23, minute=55, second=0, microsecond=0)
+    if first_arrival <= local_now + timedelta(minutes=3):
+        first_arrival += timedelta(days=1)
+    second_arrival = first_arrival + timedelta(minutes=10)
+
+    feed = gtfs_realtime_pb2.FeedMessage()
+    feed.header.gtfs_realtime_version = "2.0"
+    entity = feed.entity.add(id="e1")
+    entity.trip_update.trip.trip_id = "trip-1"
+    entity.trip_update.trip.route_id = "route-1"
+
+    later_update = entity.trip_update.stop_time_update.add()
+    later_update.stop_id = "stop-1"
+    later_update.arrival.time = int(second_arrival.timestamp())
+
+    earlier_update = entity.trip_update.stop_time_update.add()
+    earlier_update.stop_id = "stop-1"
+    earlier_update.arrival.time = int(first_arrival.timestamp())
+
+    async def fake_ensure_caches_initialized():
+        return None
+
+    async def fake_fetch_feed(url):
+        return feed
+
+    monkeypatch.setattr(api, "_ensure_caches_initialized", fake_ensure_caches_initialized)
+    monkeypatch.setattr(api, "_fetch_feed", fake_fetch_feed)
+    monkeypatch.setattr(api, "TRIP_UPDATES_URL", "https://example.test/trips")
+    monkeypatch.setattr(api, "_last_waiting_times_result", None)
+    monkeypatch.setattr(api, "_last_waiting_times_update", None)
+    monkeypatch.setattr(
+        api,
+        "_stops_cache",
+        {"stop-1": {"name": "Namur Gare", "lat": 50.466, "lon": 4.866}},
+    )
+    monkeypatch.setattr(
+        api,
+        "_routes_cache",
+        {"route-1": {"route_short_name": "12", "route_type": 3}},
+    )
+    monkeypatch.setattr(
+        api,
+        "_trips_cache",
+        {"trip-1": {"route_id": "route-1", "headsign": "Jambes"}},
+    )
+    monkeypatch.setattr(
+        api,
+        "_stop_times_cache",
+        {"trip-1": [{"stop_id": "stop-1", "stop_sequence": 1}]},
+    )
+
+    result = asyncio.run(api.get_waiting_times("stop-1"))
+
+    times = result["stops_data"]["stop-1"]["lines"]["12"]["Jambes"]
+    assert [time["timestamp"] for time in times] == [
+        earlier_update.arrival.time,
+        later_update.arrival.time,
+    ]
+
+
+def test_get_waiting_times_uses_static_schedule_for_delay_only_updates(monkeypatch):
+    scheduled_time = datetime.now(ZoneInfo("Europe/Brussels")) + timedelta(minutes=15)
+
+    feed = gtfs_realtime_pb2.FeedMessage()
+    feed.header.gtfs_realtime_version = "2.0"
+    entity = feed.entity.add(id="e1")
+    entity.trip_update.trip.trip_id = "gt:tec:trip-1"
+    entity.trip_update.trip.route_id = "gr:tec:route-1"
+    entity.trip_update.trip.start_date = scheduled_time.strftime("%Y%m%d")
+    stop_update = entity.trip_update.stop_time_update.add()
+    stop_update.stop_id = "gs:tec:stop-1"
+    stop_update.stop_sequence = 1
+    stop_update.arrival.delay = 120
+
+    async def fake_ensure_caches_initialized():
+        return None
+
+    async def fake_fetch_feed(url):
+        return feed
+
+    monkeypatch.setattr(api, "_ensure_caches_initialized", fake_ensure_caches_initialized)
+    monkeypatch.setattr(api, "_fetch_feed", fake_fetch_feed)
+    monkeypatch.setattr(api, "TRIP_UPDATES_URL", "https://example.test/trips")
+    monkeypatch.setattr(api, "_last_waiting_times_result", None)
+    monkeypatch.setattr(api, "_last_waiting_times_update", None)
+    monkeypatch.setattr(
+        api,
+        "_stops_cache",
+        {"stop-1": {"name": "Namur Gare", "lat": 50.466, "lon": 4.866}},
+    )
+    monkeypatch.setattr(
+        api,
+        "_routes_cache",
+        {"route-1": {"route_short_name": "12", "route_type": 3}},
+    )
+    monkeypatch.setattr(
+        api,
+        "_trips_cache",
+        {"trip-1": {"route_id": "route-1", "headsign": "Jambes"}},
+    )
+    monkeypatch.setattr(
+        api,
+        "_stop_times_cache",
+        {
+            "trip-1": [
+                {
+                    "stop_id": "stop-1",
+                    "stop_sequence": 1,
+                    "arrival_time": scheduled_time.strftime("%H:%M:%S"),
+                    "departure_time": scheduled_time.strftime("%H:%M:%S"),
+                }
+            ]
+        },
+    )
+
+    result = asyncio.run(api.get_waiting_times("stop-1"))
+
+    departure = result["stops_data"]["stop-1"]["lines"]["12"]["Jambes"][0]
+    expected_timestamp = int(
+        scheduled_time.replace(microsecond=0).timestamp()
+    ) + 120
+    assert departure["delay"] == 120
+    assert departure["timestamp"] == expected_timestamp
+    assert departure["is_realtime"] is True
 
 
 def test_get_service_alerts_formats_gtfs_rt_alert(monkeypatch):

--- a/app/transit_providers/be/letec/test_letec.py
+++ b/app/transit_providers/be/letec/test_letec.py
@@ -1,0 +1,134 @@
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+import httpx
+
+from transit_providers.be.letec import api
+from google.transit import gtfs_realtime_pb2
+
+
+def _binary_response(feed):
+    return httpx.Response(
+        200,
+        headers={"content-type": "application/x-protobuf"},
+        content=feed.SerializeToString(),
+        request=httpx.Request("GET", "https://example.test"),
+    )
+
+
+def test_parse_realtime_feed_accepts_binary_protobuf():
+    feed = gtfs_realtime_pb2.FeedMessage()
+    feed.header.gtfs_realtime_version = "2.0"
+    feed.entity.add(id="trip-1").trip_update.trip.trip_id = "t1"
+
+    parsed = api._parse_realtime_feed(_binary_response(feed))
+
+    assert parsed.header.gtfs_realtime_version == "2.0"
+    assert parsed.entity[0].id == "trip-1"
+    assert parsed.entity[0].trip_update.trip.trip_id == "t1"
+
+
+def test_get_waiting_times_formats_trip_updates(monkeypatch):
+    now = datetime.now(timezone.utc)
+    feed = gtfs_realtime_pb2.FeedMessage()
+    feed.header.gtfs_realtime_version = "2.0"
+    entity = feed.entity.add(id="e1")
+    entity.trip_update.trip.trip_id = "trip-1"
+    entity.trip_update.trip.route_id = "route-1"
+    stop_update = entity.trip_update.stop_time_update.add()
+    stop_update.stop_id = "stop-1"
+    stop_update.arrival.time = int((now + timedelta(minutes=5)).timestamp())
+    stop_update.arrival.delay = 60
+
+    async def fake_ensure_caches_initialized():
+        return None
+
+    async def fake_fetch_feed(url):
+        return feed
+
+    monkeypatch.setattr(api, "_ensure_caches_initialized", fake_ensure_caches_initialized)
+    monkeypatch.setattr(api, "_fetch_feed", fake_fetch_feed)
+    monkeypatch.setattr(api, "TRIP_UPDATES_URL", "https://example.test/trips")
+    monkeypatch.setattr(api, "_last_waiting_times_result", None)
+    monkeypatch.setattr(api, "_last_waiting_times_update", None)
+    monkeypatch.setattr(
+        api,
+        "_stops_cache",
+        {"stop-1": {"name": "Namur Gare", "lat": 50.466, "lon": 4.866}},
+    )
+    monkeypatch.setattr(
+        api,
+        "_routes_cache",
+        {
+            "route-1": {
+                "route_short_name": "12",
+                "route_long_name": "Namur - Jambes",
+                "route_desc": "",
+                "route_type": 3,
+            }
+        },
+    )
+    monkeypatch.setattr(
+        api,
+        "_trips_cache",
+        {"trip-1": {"route_id": "route-1", "headsign": "Jambes"}},
+    )
+    monkeypatch.setattr(
+        api,
+        "_stop_times_cache",
+        {
+            "trip-1": [
+                {"stop_id": "stop-1", "stop_sequence": 1},
+                {"stop_id": "stop-2", "stop_sequence": 2},
+            ]
+        },
+    )
+
+    result = asyncio.run(api.get_waiting_times("stop-1"))
+
+    line = result["stops_data"]["stop-1"]["lines"]["12"]
+    assert line["_metadata"]["route_id"] == "route-1"
+    assert line["Jambes"][0]["provider"] == "letec"
+    assert line["Jambes"][0]["delay"] == 60
+    assert line["Jambes"][0]["is_realtime"] is True
+
+
+def test_get_service_alerts_formats_gtfs_rt_alert(monkeypatch):
+    feed = gtfs_realtime_pb2.FeedMessage()
+    feed.header.gtfs_realtime_version = "2.0"
+    entity = feed.entity.add(id="alert-1")
+    alert = entity.alert
+    alert.cause = gtfs_realtime_pb2.Alert.CONSTRUCTION
+    alert.effect = gtfs_realtime_pb2.Alert.DETOUR
+    header = alert.header_text.translation.add()
+    header.language = "en"
+    header.text = "Works"
+    description = alert.description_text.translation.add()
+    description.language = "en"
+    description.text = "Line diverted"
+    informed = alert.informed_entity.add()
+    informed.route_id = "route-1"
+
+    async def fake_fetch_feed(url):
+        return feed
+
+    monkeypatch.setattr(api, "_fetch_feed", fake_fetch_feed)
+    monkeypatch.setattr(api, "SERVICE_ALERTS_URL", "https://example.test/alerts")
+
+    result = asyncio.run(api.get_service_alerts())
+
+    assert result == [
+        {
+            "id": "alert-1",
+            "provider": "letec",
+            "cause": "CONSTRUCTION",
+            "effect": "DETOUR",
+            "header": {"en": "Works"},
+            "description": {"en": "Line diverted"},
+            "url": {},
+            "active_periods": [],
+            "informed_entities": [
+                {"agency_id": None, "route_id": "route-1", "stop_id": None}
+            ],
+        }
+    ]

--- a/app/transit_providers/be/mobility.py
+++ b/app/transit_providers/be/mobility.py
@@ -56,4 +56,7 @@ def mobility_subscription_headers(
 
     if not key:
         return {}
-    return {"bmc-partner-key": key}
+    return {
+        "Ocp-Apim-Subscription-Key": key,
+        "bmc-partner-key": key,
+    }

--- a/app/transit_providers/be/sncb/readme.md
+++ b/app/transit_providers/be/sncb/readme.md
@@ -14,6 +14,6 @@ The provider uses Belgian Mobility APIM by default:
 - Static GTFS: `/api/gtfs/feed/nmbssncb/static`
 - Realtime trip updates: `/api/gtfs/feed/nmbssncb/rt/trip-update`
 
-Set `MOBILITY_API_PRIMARY_KEY` or `MOBILITY_API_SECONDARY_KEY` in `.env`. The app sends the key as the `bmc-partner-key` header.
+Set `MOBILITY_API_PRIMARY_KEY` or `MOBILITY_API_SECONDARY_KEY` in `.env`. The app sends the key as both `Ocp-Apim-Subscription-Key` and `bmc-partner-key` for Belgian Mobility APIM compatibility.
 
 The old SNCB GTFS-RT URL can still be used only by setting `SNCB_REALTIME_SOURCE=legacy` and `SNCB_LEGACY_GTFS_REALTIME_API_URL`. GTFS.be remains useful for static GTFS fallback through Mobility Database, but its `tripUpdates.pb` mirror is not used because it is not reliably live.

--- a/app/transit_providers/be/stib/mobility.py
+++ b/app/transit_providers/be/stib/mobility.py
@@ -28,7 +28,10 @@ def mobility_subscription_headers() -> Dict[str, str]:
         )
     if not key:
         return {}
-    return {"bmc-partner-key": key}
+    return {
+        "Ocp-Apim-Subscription-Key": key,
+        "bmc-partner-key": key,
+    }
 
 
 def mobility_url(path: str) -> str:

--- a/app/transit_providers/be/stib/test_mobility.py
+++ b/app/transit_providers/be/stib/test_mobility.py
@@ -42,5 +42,6 @@ def test_mobility_subscription_headers_from_provider_config(monkeypatch):
 
     monkeypatch.setattr(mobility_mod, "get_provider_config", fake_pc)
     assert mobility_subscription_headers() == {
+        "Ocp-Apim-Subscription-Key": "k-from-provider-config",
         "bmc-partner-key": "k-from-provider-config",
     }

--- a/app/transit_providers/be/test_mobility.py
+++ b/app/transit_providers/be/test_mobility.py
@@ -41,5 +41,6 @@ def test_mobility_subscription_headers_reads_top_level_config(monkeypatch):
     monkeypatch.setattr(mobility, "get_provider_config", lambda provider: {})
 
     assert mobility_subscription_headers("sncb") == {
+        "Ocp-Apim-Subscription-Key": "top-level-key",
         "bmc-partner-key": "top-level-key"
     }

--- a/app/transit_providers/config.py
+++ b/app/transit_providers/config.py
@@ -11,6 +11,11 @@ logger = logging.getLogger("transit_providers.config")
 
 # Registry for provider default configurations
 PROVIDER_DEFAULTS: Dict[str, Dict[str, Any]] = {}
+PROVIDER_ALIASES = {"tec": "letec"}
+
+
+def canonical_provider_name(provider_name: str) -> str:
+    return PROVIDER_ALIASES.get(provider_name, provider_name)
 
 
 def deep_update(base_dict: Dict, update_dict: Dict) -> Dict:
@@ -54,6 +59,7 @@ def register_provider_config(
     provider_name: str, default_config: Dict[str, Any]
 ) -> None:
     """Register a provider's default configuration"""
+    provider_name = canonical_provider_name(provider_name)
     PROVIDER_DEFAULTS[provider_name] = default_config
     logger.debug(f"Registered default config for {provider_name}")
 
@@ -65,6 +71,8 @@ def get_provider_config(provider_name: str) -> Dict[str, Any]:
     2. default.py (overrides provider defaults)
     3. local.py (most important, overrides both)
     )"""
+    provider_name = canonical_provider_name(provider_name)
+
     # Start with provider-specific defaults (least important)
     config = deepcopy(PROVIDER_DEFAULTS.get(provider_name, {}))
     logger.debug(f"Starting with provider defaults for {provider_name}: {config}")
@@ -97,7 +105,18 @@ def get_provider_config(provider_name: str) -> Dict[str, Any]:
                 config[key] = deepcopy(default_value)
 
     # Then, check PROVIDER_CONFIG in default.py
-    default_provider_config = get_config("PROVIDER_CONFIG", {}).get(provider_name, {})
+    provider_config_map = get_config("PROVIDER_CONFIG", {})
+    default_provider_config = {}
+    for alias, canonical in PROVIDER_ALIASES.items():
+        if canonical == provider_name:
+            default_provider_config = deep_update(
+                default_provider_config,
+                deepcopy(provider_config_map.get(alias, {})),
+            )
+    default_provider_config = deep_update(
+        default_provider_config,
+        deepcopy(provider_config_map.get(provider_name, {})),
+    )
     logger.debug(
         f"Provider config from default.py for {provider_name}: {default_provider_config}"
     )
@@ -107,7 +126,15 @@ def get_provider_config(provider_name: str) -> Dict[str, Any]:
 
     # Get user config from local.py and merge it (most important)
     provider_config = get_config("PROVIDER_CONFIG", {})
-    user_config = deepcopy(provider_config.get(provider_name, {}))
+    user_config = {}
+    for alias, canonical in PROVIDER_ALIASES.items():
+        if canonical == provider_name:
+            user_config = deep_update(
+                user_config, deepcopy(provider_config.get(alias, {}))
+            )
+    user_config = deep_update(
+        user_config, deepcopy(provider_config.get(provider_name, {}))
+    )
     logger.debug(f"User config from local.py for {provider_name}: {user_config}")
     if user_config:
         config = deep_update(config, user_config)

--- a/readme.md
+++ b/readme.md
@@ -147,6 +147,10 @@ Le TEC publishes static GTFS, GTFS-RT trip updates, and GTFS-RT service alerts t
 
 Use `letec` as the provider ID in this app. Belgian Mobility APIM still uses the feed slug `tec`, so the default URLs are `/api/gtfs/feed/tec/static`, `/api/gtfs/feed/tec/rt/trip-update`, and `/api/gtfs/feed/tec/rt/alert`.
 
+Le TEC GTFS-RT trip updates can use Belgian Mobility-prefixed IDs such as `gs:tec:*`, `gr:tec:*`, and `gt:tec:*`, and may publish delay-only stop updates. The provider normalizes those IDs and joins realtime delays to static GTFS `stop_times.txt` schedules before returning waiting times.
+
+Static GTFS falls back to the official HTTPS Le TEC ZIP at `https://opendata.tec-wl.be/Current%20GTFS/TEC-GTFS.zip` if APIM static GTFS is unavailable.
+
 The app does not consume Le TEC NeTEx data yet; this provider is wired for GTFS static data and GTFS-RT realtime feeds.
 
 ### BKK (Budapest)

--- a/readme.md
+++ b/readme.md
@@ -33,7 +33,7 @@ Creates a dashboard showing waiting times for implemented public transport compa
 The aim is for a modular design that allows for easy addition of new transit providers, including in other countries.
 
 Currently supported real-time waiting times:
-- Belgium: STIB, De Lijn, SNCB
+- Belgium: STIB, De Lijn, SNCB, Le TEC
 - Hungary: BKK
 
 Schedule based waiting times: supported in 70 countries covered by the Mobility Database.
@@ -136,6 +136,18 @@ SNCB/NMBS now publishes scheduled and realtime GTFS data through the [Belgian Mo
 4. Optional static fallback: add `MOBILITY_API_REFRESH_TOKEN` so the app can fall back to Mobility Database / GTFS.be static GTFS if Belgian Mobility static GTFS is temporarily unavailable.
 
 The old `SNCB_GTFS_REALTIME_API_URL` setting is deprecated. GTFS.be's `tripUpdates.pb` mirror is not used as a realtime fallback because it is not reliably updated.
+
+### Le TEC (Belgium)
+
+Le TEC publishes static GTFS, GTFS-RT trip updates, and GTFS-RT service alerts through the [Belgian Mobility Open Data Portal](https://data.belgianmobility.io/).
+
+1. Visit https://api-management-opendata-production.developer.azure-api.net/
+2. Create an account and subscribe to the Standard product.
+3. Add the primary or secondary key to `.env` as `MOBILITY_API_PRIMARY_KEY` or `MOBILITY_API_SECONDARY_KEY`.
+
+Use `letec` as the provider ID in this app. Belgian Mobility APIM still uses the feed slug `tec`, so the default URLs are `/api/gtfs/feed/tec/static`, `/api/gtfs/feed/tec/rt/trip-update`, and `/api/gtfs/feed/tec/rt/alert`.
+
+The app does not consume Le TEC NeTEx data yet; this provider is wired for GTFS static data and GTFS-RT realtime feeds.
 
 ### BKK (Budapest)
 


### PR DESCRIPTION
## Summary
- add a canonical `letec` provider backed by Belgian Mobility APIM static GTFS, GTFS-RT trip updates, and GTFS-RT service alerts
- keep `tec` as a backward-compatible alias for enabled providers, provider config, and API route access while returning canonical metadata on aliased API calls
- document Le TEC API setup, environment overrides, static fallback URLs, NeTEx non-goal, and changelog entry

## Source checks
- Le TEC open data page says static data and realtime updates are distributed through `data.belgianmobility.io`.
- Belgian Mobility FAQ lists LETEC in GTFS static and GTFS realtime coverage.
- Belgian Mobility terms require API keys for the Standard tier and identify LETEC as an operator source.
- Transitland's Belgian Mobility feed catalog lists APIM endpoints for TEC static, trip updates, and alerts, with `Ocp-Apim-Subscription-Key` authentication.
- Live endpoint probes without a key confirmed `/api/gtfs/feed/tec/static`, `/rt/trip-update`, and `/rt/alert` are protected APIM endpoints, while `/letec/static` and `/rt/vehicle-position` were not available.

## Tests
- `PROJECT_ROOT=/Users/bence/.codex/worktrees/45ec/STIB ENABLED_PROVIDERS=letec PYTHONPATH=app /tmp/stib-letec-venv/bin/python -m pytest app/transit_providers/be/letec/test_letec.py app/transit_providers/be/test_mobility.py app/transit_providers/be/stib/test_mobility.py -q`
- `python3 -m compileall app/transit_providers/be/letec app/transit_providers/config.py app/transit_providers/__init__.py app/config/default.py app/main.py`
- `git diff --check`
- `PROJECT_ROOT=/Users/bence/.codex/worktrees/45ec/STIB ENABLED_PROVIDERS=tec PYTHONPATH=app /tmp/stib-letec-venv/bin/python - <<'PY'\nfrom transit_providers import PROVIDERS\nprint(sorted(PROVIDERS.keys()))\nPY`

## Notes
- I used a temporary venv at `/tmp/stib-letec-venv` because the system Python did not have the project test dependencies installed.
- The local provider identity is `letec`; the Belgian Mobility APIM feed slug remains `tec` by default and is configurable via `LETEC_APIM_FEED_SLUG`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Le TEC (Belgian Mobility) as a new transit provider with real-time waiting times, service alerts, and stop information.
  * Implemented provider name aliasing for flexible configuration options.

* **Documentation**
  * Updated configuration examples and README with Le TEC setup instructions and Belgian Mobility API access details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->