### PR TITLE
[codex] Migrate De Lijn GTFS to Belgian Mobility

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -13,6 +13,15 @@ DELIJN_GTFS_REALTIME_API_KEY=your-delijn-gtfs-realtime-key-here
 BKK_API_KEY=your-bkk-api-key-here
 MOBILITY_API_REFRESH_TOKEN=your-mobility-api-refresh-token-here
 
+# De Lijn uses Belgian Mobility for static GTFS and GTFS-RT service alerts by default.
+# Legacy De Lijn keys above remain the fallback and are still required for vehicle positions.
+# DELIJN_GTFS_STATIC_SOURCE=belgian_mobility
+# DELIJN_SERVICE_ALERTS_SOURCE=belgian_mobility
+# DELIJN_VEHICLE_POSITIONS_SOURCE=legacy
+# DELIJN_BELGIAN_MOBILITY_GTFS_STATIC_URL=https://opendata-discovery-gtfs-static.api.production.belgianmobility.io/api/gtfs/feed/delijn/static
+# DELIJN_BELGIAN_MOBILITY_ALERTS_URL=https://api-management-opendata-production.azure-api.net/api/gtfs/feed/delijn/rt/alert
+# DELIJN_BELGIAN_MOBILITY_TRIP_UPDATES_URL=https://api-management-opendata-production.azure-api.net/api/gtfs/feed/delijn/rt/trip-update
+
 # SNCB/NMBS uses Belgian Mobility APIM by default for static GTFS and realtime trip updates.
 # Requires MOBILITY_API_PRIMARY_KEY or MOBILITY_API_SECONDARY_KEY above for APIM authentication.
 # Optional overrides:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 
 [Full Changelog](https://github.com/bdamokos/brussels_transit/compare/v0.2.8...v0.2.9)
 
-**De Lijn — Belgian Mobility Open Data**
+**De Lijn — Belgian Mobility Open Data** [\#129](https://github.com/bdamokos/brussels_transit/pull/129)
 
 - Use Belgian Mobility as the primary De Lijn static GTFS source, with legacy De Lijn static GTFS fallback.
 - Normalize Belgian Mobility De Lijn GTFS IDs back to the app's existing stop, route, trip, service, and shape ID format.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,13 @@
 
 [Full Changelog](https://github.com/bdamokos/brussels_transit/compare/v0.2.8...v0.2.9)
 
+**De Lijn — Belgian Mobility Open Data**
+
+- Use Belgian Mobility as the primary De Lijn static GTFS source, with legacy De Lijn static GTFS fallback.
+- Normalize Belgian Mobility De Lijn GTFS IDs back to the app's existing stop, route, trip, service, and shape ID format.
+- Use Belgian Mobility GTFS-RT service alerts by default, with legacy `storingen` / `omleidingen` fallback.
+- Keep De Lijn vehicle positions on the legacy GTFS realtime endpoint; Belgian Mobility TripUpdates are not treated as vehicle-position data.
+
 **SNCB/NMBS — Belgian Mobility Open Data (Azure APIM)**
 
 - Use Belgian Mobility APIM as the primary SNCB static GTFS and realtime trip-update source.

--- a/DOCKER.md
+++ b/DOCKER.md
@@ -153,6 +153,9 @@ STIB_API_KEY=your_stib_api_key
 DELIJN_API_KEY=your_delijn_api_key
 DELIJN_GTFS_STATIC_API_KEY=your_delijn_gtfs_static_key
 DELIJN_GTFS_REALTIME_API_KEY=your_delijn_gtfs_realtime_key
+DELIJN_GTFS_STATIC_SOURCE=belgian_mobility
+DELIJN_SERVICE_ALERTS_SOURCE=belgian_mobility
+DELIJN_VEHICLE_POSITIONS_SOURCE=legacy
 BKK_API_KEY=your_bkk_api_key
 MOBILITY_API_REFRESH_TOKEN=your_mobility_api_refresh_token # optional static GTFS fallback
 

--- a/app/config/default.py
+++ b/app/config/default.py
@@ -115,7 +115,10 @@ API_CONFIG = {
     "STIB_API_URL": "https://data.stib-mivb.brussels/api/explore/v2.1/catalog/datasets",
     "STIB_STOPS_API_URL": "https://data.stib-mivb.brussels/api/explore/v2.1/catalog/datasets/stop-details-production/records",
     "DELIJN_API_URL": "https://api.delijn.be/DLKernOpenData/api/v1",
-    "DELIJN_GTFS_URL": "https://api.delijn.be/gtfs/static/v3/gtfs_transit.zip",
+    "DELIJN_GTFS_URL": os.getenv(
+        "DELIJN_BELGIAN_MOBILITY_GTFS_STATIC_URL",
+        "https://opendata-discovery-gtfs-static.api.production.belgianmobility.io/api/gtfs/feed/delijn/static",
+    ),
 }
 
 # Cache Configuration
@@ -214,7 +217,14 @@ PROVIDER_CONFIG = {
         "provider_specific": {
             "API_URL": "https://api.delijn.be/DLKernOpenData/api/v1",
             "_AVAILABLE_LANGUAGES": ["nl"],
-            "GTFS_URL": "https://api.delijn.be/gtfs/static/v3/gtfs_transit.zip",
+            "GTFS_STATIC_SOURCE": os.getenv(
+                "DELIJN_GTFS_STATIC_SOURCE", "belgian_mobility"
+            ),
+            "GTFS_URL": os.getenv(
+                "DELIJN_BELGIAN_MOBILITY_GTFS_STATIC_URL",
+                "https://opendata-discovery-gtfs-static.api.production.belgianmobility.io/api/gtfs/feed/delijn/static",
+            ),
+            "LEGACY_GTFS_URL": "https://api.delijn.be/gtfs/static/v3/gtfs_transit.zip",
             "GTFS_DIR": CACHE_DIR / "delijn/gtfs",
             "CACHE_DIR": CACHE_DIR / "delijn",
             "RATE_LIMIT_DELAY": 0.5,
@@ -222,6 +232,37 @@ PROVIDER_CONFIG = {
             "API_KEY": os.getenv("DELIJN_API_KEY"),
             "GTFS_STATIC_API_KEY": os.getenv("DELIJN_GTFS_STATIC_API_KEY"),
             "GTFS_REALTIME_API_KEY": os.getenv("DELIJN_GTFS_REALTIME_API_KEY"),
+            "MOBILITY_API_PRIMARY_KEY": os.getenv("MOBILITY_API_PRIMARY_KEY"),
+            "MOBILITY_API_SECONDARY_KEY": os.getenv("MOBILITY_API_SECONDARY_KEY"),
+            "SERVICE_ALERTS_SOURCE": os.getenv(
+                "DELIJN_SERVICE_ALERTS_SOURCE", "belgian_mobility"
+            ),
+            "BELGIAN_MOBILITY_ALERTS_URL": os.getenv(
+                "DELIJN_BELGIAN_MOBILITY_ALERTS_URL",
+                (
+                    os.getenv(
+                        "MOBILITY_APIM_BASE_URL",
+                        "https://api-management-opendata-production.azure-api.net",
+                    ).rstrip("/")
+                    + "/api/gtfs/feed/delijn/rt/alert"
+                ),
+            ),
+            "BELGIAN_MOBILITY_TRIP_UPDATES_URL": os.getenv(
+                "DELIJN_BELGIAN_MOBILITY_TRIP_UPDATES_URL",
+                (
+                    os.getenv(
+                        "MOBILITY_APIM_BASE_URL",
+                        "https://api-management-opendata-production.azure-api.net",
+                    ).rstrip("/")
+                    + "/api/gtfs/feed/delijn/rt/trip-update"
+                ),
+            ),
+            "VEHICLE_POSITIONS_SOURCE": os.getenv(
+                "DELIJN_VEHICLE_POSITIONS_SOURCE", "legacy"
+            ),
+            "BELGIAN_MOBILITY_VEHICLE_POSITIONS_URL": os.getenv(
+                "DELIJN_BELGIAN_MOBILITY_VEHICLE_POSITIONS_URL"
+            ),
             "GTFS_USED_FILES": ["stops.txt", "routes.txt", "trips.txt", "shapes.txt"],
         },
         "stops": [

--- a/app/config/local.py.example
+++ b/app/config/local.py.example
@@ -15,6 +15,14 @@ STIB_API_KEY = "your-stib-api-key"
 DELIJN_API_KEY = "your-delijn-api-key"
 DELIJN_GTFS_STATIC_API_KEY = "your-delijn-gtfs-static-key"
 DELIJN_GTFS_REALTIME_API_KEY = "your-delijn-gtfs-realtime-key"
+# De Lijn defaults to Belgian Mobility for static GTFS and service alerts.
+# Legacy De Lijn remains the fallback and the only vehicle-position provider for now.
+# DELIJN_GTFS_STATIC_SOURCE = "belgian_mobility"
+# DELIJN_SERVICE_ALERTS_SOURCE = "belgian_mobility"
+# DELIJN_VEHICLE_POSITIONS_SOURCE = "legacy"
+# DELIJN_BELGIAN_MOBILITY_GTFS_STATIC_URL = "https://opendata-discovery-gtfs-static.api.production.belgianmobility.io/api/gtfs/feed/delijn/static"
+# DELIJN_BELGIAN_MOBILITY_ALERTS_URL = "https://api-management-opendata-production.azure-api.net/api/gtfs/feed/delijn/rt/alert"
+# DELIJN_BELGIAN_MOBILITY_TRIP_UPDATES_URL = "https://api-management-opendata-production.azure-api.net/api/gtfs/feed/delijn/rt/trip-update"
 
 # Override any default settings here
 MAP_CONFIG = {

--- a/app/transit_providers/be/delijn/__init__.py
+++ b/app/transit_providers/be/delijn/__init__.py
@@ -31,6 +31,7 @@ from .api import (
     get_nearest_stop,
     find_nearest_stops,
     get_stop_by_name,
+    get_realtime_source_status,
 )
 
 provider_config = get_provider_config("delijn")
@@ -68,6 +69,7 @@ class DelijnProvider(TransitProvider):
             "nearest_stop": get_nearest_stop,
             "get_stop_by_name": self.get_stop_by_name,
             "get_nearest_stops": self.get_nearest_stops,
+            "realtime_sources": get_realtime_source_status,
         }
 
         # Call parent class constructor

--- a/app/transit_providers/be/delijn/api.py
+++ b/app/transit_providers/be/delijn/api.py
@@ -15,6 +15,7 @@ import asyncio
 from transit_providers.config import get_provider_config
 import pytz
 from dataclasses import asdict
+import shutil
 from transit_providers.nearest_stop import (
     ingest_gtfs_stops,
     get_nearest_stops,
@@ -28,6 +29,12 @@ import time
 import csv
 from functools import lru_cache
 import hashlib
+from transit_providers.be.mobility import mobility_subscription_headers
+from .ids import (
+    normalize_delijn_stop_id,
+    normalize_static_gtfs_dir,
+    strip_delijn_id_prefix,
+)
 
 
 # Get logger
@@ -40,6 +47,9 @@ logger.debug(f"Provider config: {provider_config}")
 # API configuration
 API_URL = provider_config.get("API_URL")
 GTFS_URL = provider_config.get("GTFS_URL")
+LEGACY_GTFS_URL = provider_config.get(
+    "LEGACY_GTFS_URL", "https://api.delijn.be/gtfs/static/v3/gtfs_transit.zip"
+)
 
 
 GTFS_DIR = provider_config.get("GTFS_DIR")
@@ -56,6 +66,22 @@ BASE_URL = provider_config.get("API_URL")
 DELIJN_API_KEY = provider_config.get("API_KEY")
 DELIJN_GTFS_STATIC_API_KEY = provider_config.get("GTFS_STATIC_API_KEY")
 DELIJN_GTFS_REALTIME_API_KEY = provider_config.get("GTFS_REALTIME_API_KEY")
+GTFS_STATIC_SOURCE = str(
+    provider_config.get("GTFS_STATIC_SOURCE", "belgian_mobility")
+).lower()
+SERVICE_ALERTS_SOURCE = str(
+    provider_config.get("SERVICE_ALERTS_SOURCE", "belgian_mobility")
+).lower()
+BELGIAN_MOBILITY_ALERTS_URL = provider_config.get("BELGIAN_MOBILITY_ALERTS_URL")
+BELGIAN_MOBILITY_TRIP_UPDATES_URL = provider_config.get(
+    "BELGIAN_MOBILITY_TRIP_UPDATES_URL"
+)
+VEHICLE_POSITIONS_SOURCE = str(
+    provider_config.get("VEHICLE_POSITIONS_SOURCE", "legacy")
+).lower()
+BELGIAN_MOBILITY_VEHICLE_POSITIONS_URL = provider_config.get(
+    "BELGIAN_MOBILITY_VEHICLE_POSITIONS_URL"
+)
 
 # Configuration
 STOP_ID = provider_config.get("STOP_IDS")
@@ -132,6 +158,63 @@ class ProgressTracker:
                 f"ETA: {estimated_time_remaining:.1f}s"
             )
             self.last_update = current_time
+
+
+def _required_gtfs_files() -> List[str]:
+    return list(
+        GTFS_USED_FILES or ["stops.txt", "routes.txt", "trips.txt", "shapes.txt"]
+    )
+
+
+def _gtfs_dir_has_required_files(path: Path) -> bool:
+    return path.exists() and all(
+        (path / filename).exists() for filename in _required_gtfs_files()
+    )
+
+
+def _safe_extract_zip(zf: zipfile.ZipFile, dest_dir: Path) -> None:
+    """Extract ZIP members under dest_dir only."""
+    dest_root = dest_dir.resolve()
+    for member in zf.infolist():
+        name = member.filename
+        if not name or name.endswith("/"):
+            continue
+        target = (dest_root / name).resolve()
+        try:
+            target.relative_to(dest_root)
+        except ValueError:
+            logger.warning("Skipping ZIP entry outside GTFS dir: %s", name)
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        with zf.open(member, "r") as src, open(target, "wb") as out_f:
+            shutil.copyfileobj(src, out_f)
+
+
+def _mobility_headers() -> Dict[str, str]:
+    headers = mobility_subscription_headers(
+        "delijn",
+        legacy_env_keys=("DELIJN_GTFS_REALTIME_API_KEY", "DELIJN_API_KEY"),
+        legacy_config_keys=("GTFS_REALTIME_API_KEY", "API_KEY"),
+    )
+    key = headers.get("bmc-partner-key")
+    if key:
+        headers["Ocp-Apim-Subscription-Key"] = key
+    return headers
+
+
+def _legacy_headers(api_key: Optional[str]) -> Dict[str, str]:
+    headers = {"Cache-Control": "no-cache"}
+    if api_key:
+        headers["Ocp-Apim-Subscription-Key"] = api_key
+    return headers
+
+
+def _service_alerts_use_belgian_mobility() -> bool:
+    return SERVICE_ALERTS_SOURCE in {"belgian_mobility", "mobility", "apim"}
+
+
+def _gtfs_static_use_belgian_mobility() -> bool:
+    return GTFS_STATIC_SOURCE in {"belgian_mobility", "mobility", "apim"}
 
 
 async def cache_get(cache_key: str) -> Optional[Any]:
@@ -372,6 +455,37 @@ async def get_line_color(line_number: str) -> Optional[Dict[str, str]]:
         logger.error(
             f"Error getting line colors for line {line_number}: {str(e)}", exc_info=True
         )
+    return await get_line_color_from_gtfs(line_number)
+
+
+async def get_line_color_from_gtfs(line_number: str) -> Optional[Dict[str, str]]:
+    """Get color information for a line from static GTFS routes.txt."""
+    try:
+        gtfs_dir = await ensure_gtfs_data()
+        if not gtfs_dir:
+            return None
+
+        routes_file = gtfs_dir / "routes.txt"
+        if not routes_file.exists():
+            return None
+
+        for route in iter_gtfs_file(routes_file):
+            if route.get("route_short_name") != str(line_number):
+                continue
+            background = route.get("route_color")
+            text = route.get("route_text_color")
+            if not background:
+                return None
+            color_data = {
+                "text": f"#{text}" if text else "#FFFFFF",
+                "background": f"#{background}",
+                "text_border": f"#{text}" if text else "#FFFFFF",
+                "background_border": f"#{background}",
+            }
+            await cache_set(f"line_color_{line_number}", color_data)
+            return color_data
+    except Exception as exc:
+        logger.error("Error reading line color from GTFS for %s: %s", line_number, exc)
     return None
 
 
@@ -598,7 +712,7 @@ async def get_formatted_arrivals(stop_ids: List[str] = None) -> Dict:
 
 
 async def download_and_extract_gtfs() -> bool:
-    """Download and extract fresh GTFS data with file locking"""
+    """Download and extract fresh GTFS data with file locking."""
     lock_file = CACHE_DIR / "gtfs_download.lock"
 
     # Check if we already have recent GTFS data
@@ -607,7 +721,7 @@ async def download_and_extract_gtfs() -> bool:
         all_files_exist = True
         oldest_file_age = 0
 
-        for filename in GTFS_USED_FILES:
+        for filename in _required_gtfs_files():
             file_path = GTFS_DIR / filename
             if not file_path.exists():
                 logger.info(
@@ -675,7 +789,7 @@ async def download_and_extract_gtfs() -> bool:
             if GTFS_DIR.exists():
                 all_files_exist = True
                 oldest_file_age = 0
-                for filename in GTFS_USED_FILES:
+                for filename in _required_gtfs_files():
                     file_path = GTFS_DIR / filename
                     if not file_path.exists():
                         all_files_exist = False
@@ -689,52 +803,41 @@ async def download_and_extract_gtfs() -> bool:
                     )
                     return True
 
-            logger.info("Starting GTFS data download")
+            source_attempts = []
+            if _gtfs_static_use_belgian_mobility():
+                source_attempts.append(
+                    (
+                        "belgian_mobility",
+                        GTFS_URL,
+                        _mobility_headers() or {"Cache-Control": "no-cache"},
+                    )
+                )
+                source_attempts.append(
+                    (
+                        "legacy",
+                        LEGACY_GTFS_URL,
+                        _legacy_headers(DELIJN_GTFS_STATIC_API_KEY),
+                    )
+                )
+            else:
+                source_attempts.append(
+                    (
+                        "legacy",
+                        LEGACY_GTFS_URL,
+                        _legacy_headers(DELIJN_GTFS_STATIC_API_KEY),
+                    )
+                )
 
-            headers = {
-                "Cache-Control": "no-cache",
-                "Ocp-Apim-Subscription-Key": DELIJN_GTFS_STATIC_API_KEY,
-            }
+            for source, url, headers in source_attempts:
+                if not url:
+                    continue
+                logger.info("Starting De Lijn GTFS download from %s", source)
+                if await _download_gtfs_source(source, url, headers):
+                    return True
+                logger.warning("De Lijn GTFS download from %s failed", source)
 
-            # Get file size and download with progress tracking
-            response = requests.get(GTFS_URL, headers=headers, stream=True)
-            response.raise_for_status()
-            total_size = int(response.headers.get("content-length", 0))
-            logger.info(f"GTFS file size: {total_size/(1024*1024):.1f}MB")
-
-            logger.debug("Saving GTFS zip file")
-            progress = ProgressTracker(total_size)
-
-            with open("gtfs_transit.zip", "wb") as f_zip:
-                for chunk in response.iter_content(chunk_size=8192):
-                    if chunk:
-                        f_zip.write(chunk)
-                        progress.update(len(chunk))
-
-            logger.debug("Extracting GTFS data")
-            GTFS_DIR.mkdir(exist_ok=True)
-            try:
-                with zipfile.ZipFile("gtfs_transit.zip", "r") as zip_ref:
-                    zip_ref.extractall(GTFS_DIR)
-                    logger.debug(f"Extracted GTFS data to {GTFS_DIR}")
-            except Exception as e:
-                logger.error(f"Error extracting GTFS data: {e}", exc_info=True)
-
-            # Clean up zip file
-            try:
-                Path("gtfs_transit.zip").unlink()
-                logger.debug("Deleted GTFS zip file")
-            except Exception as e:
-                logger.error(f"Error deleting GTFS zip file: {e}", exc_info=True)
-
-            # Clean up unused files
-            for file in GTFS_DIR.glob("*"):
-                if file.name not in GTFS_USED_FILES:
-                    file.unlink()
-                    logger.debug(f"Deleted unused GTFS file: {file.name}")
-
-            logger.info("GTFS data updated successfully")
-            return True
+            logger.error("All De Lijn GTFS download sources failed")
+            return False
 
         finally:
             # Release the fcntl lock by closing the FD, then remove the lock file
@@ -757,6 +860,82 @@ async def download_and_extract_gtfs() -> bool:
     except Exception as e:
         logger.error(f"Error updating GTFS data: {str(e)}", exc_info=True)
         return False
+
+
+async def _download_gtfs_source(source: str, url: str, headers: Dict[str, str]) -> bool:
+    tmp_dir = GTFS_DIR.parent / f".{GTFS_DIR.name}.{source}.tmp"
+    tmp_zip = CACHE_DIR / f"gtfs_transit.{source}.zip"
+
+    if tmp_dir.exists():
+        shutil.rmtree(tmp_dir)
+    if tmp_zip.exists():
+        tmp_zip.unlink()
+
+    try:
+        response = requests.get(url, headers=headers, stream=True, timeout=120)
+        response.raise_for_status()
+        total_size = int(response.headers.get("content-length", 0))
+        if total_size:
+            logger.info(
+                "GTFS file size from %s: %.1fMB",
+                source,
+                total_size / (1024 * 1024),
+            )
+
+        progress = ProgressTracker(total_size) if total_size else None
+        with open(tmp_zip, "wb") as f_zip:
+            for chunk in response.iter_content(chunk_size=1024 * 1024):
+                if chunk:
+                    f_zip.write(chunk)
+                    if progress:
+                        progress.update(len(chunk))
+
+        tmp_dir.mkdir(parents=True)
+        with zipfile.ZipFile(tmp_zip, "r") as zip_ref:
+            _safe_extract_zip(zip_ref, tmp_dir)
+
+        if source == "belgian_mobility":
+            normalize_static_gtfs_dir(tmp_dir)
+
+        missing_files = [
+            filename
+            for filename in _required_gtfs_files()
+            if not (tmp_dir / filename).exists()
+        ]
+        if missing_files:
+            logger.error("GTFS download from %s missing files: %s", source, missing_files)
+            return False
+
+        for file in tmp_dir.glob("*"):
+            if file.name not in _required_gtfs_files():
+                file.unlink()
+                logger.debug("Deleted unused GTFS file: %s", file.name)
+
+        if GTFS_DIR.exists():
+            shutil.rmtree(GTFS_DIR)
+        tmp_dir.rename(GTFS_DIR)
+
+        metadata = {
+            "downloaded_at": datetime.now(timezone.utc).isoformat(),
+            "source": source,
+            "source_url": url,
+            "last_modified": response.headers.get("last-modified"),
+            "etag": response.headers.get("etag"),
+        }
+        (CACHE_DIR / "gtfs_metadata.json").write_text(
+            json.dumps(metadata, indent=2), encoding="utf-8"
+        )
+
+        logger.info("GTFS data updated successfully from %s", source)
+        return True
+    except Exception as exc:
+        logger.error("Error downloading De Lijn GTFS from %s: %s", source, exc)
+        return False
+    finally:
+        if tmp_zip.exists():
+            tmp_zip.unlink()
+        if tmp_dir.exists():
+            shutil.rmtree(tmp_dir)
 
 
 def iter_gtfs_file(file_path: Path) -> Generator[Dict[str, str], None, None]:
@@ -939,6 +1118,13 @@ async def get_vehicle_positions(
 ) -> List[Dict]:
     """Get real-time positions of vehicles for a specific line"""
     try:
+        if VEHICLE_POSITIONS_SOURCE != "legacy":
+            logger.warning(
+                "Ignoring DELIJN_VEHICLE_POSITIONS_SOURCE=%s; De Lijn vehicle "
+                "positions remain legacy-only until Belgian Mobility exposes "
+                "comparable VehiclePositions data.",
+                VEHICLE_POSITIONS_SOURCE,
+            )
         logger.info(f"\n=== Fetching vehicle positions for line {line_number} ===")
 
         # First get the route ID from GTFS data
@@ -1092,6 +1278,26 @@ async def get_vehicle_positions(
         return []
 
 
+async def get_realtime_source_status() -> Dict[str, Any]:
+    """Report De Lijn realtime source selection and vehicle-position compatibility."""
+    return {
+        "gtfs_static_source": GTFS_STATIC_SOURCE,
+        "service_alerts_source": SERVICE_ALERTS_SOURCE,
+        "vehicle_positions_source": "legacy",
+        "legacy_vehicle_positions_url": "https://api.delijn.be/gtfs/v3/realtime",
+        "belgian_mobility_trip_updates_url": BELGIAN_MOBILITY_TRIP_UPDATES_URL,
+        "belgian_mobility_alerts_url": BELGIAN_MOBILITY_ALERTS_URL,
+        "belgian_mobility_vehicle_positions_url": BELGIAN_MOBILITY_VEHICLE_POSITIONS_URL,
+        "belgian_mobility_vehicle_positions_comparable": bool(
+            BELGIAN_MOBILITY_VEHICLE_POSITIONS_URL
+        ),
+        "notes": [
+            "Belgian Mobility De Lijn TripUpdates can support delay/arrival work, but it is not a vehicle-position feed.",
+            "No Belgian Mobility De Lijn VehiclePositions endpoint is configured by default.",
+        ],
+    }
+
+
 def message_is_duplicate(msg1: dict, msg2: dict) -> bool:
     """Compare two messages to determine if they are duplicates.
 
@@ -1134,11 +1340,217 @@ def message_is_duplicate(msg1: dict, msg2: dict) -> bool:
     return True
 
 
+def _translation_text(value: Dict[str, Any]) -> Optional[str]:
+    translations = value.get("translation") or value.get("translations") or []
+    if isinstance(translations, dict):
+        translations = [translations]
+    if not translations:
+        return value.get("text") if isinstance(value, dict) else None
+
+    preferred_languages = get_config("LANGUAGE_PRECEDENCE", ["nl", "en", "fr"])
+    for lang in preferred_languages:
+        for item in translations:
+            if item.get("language") == lang and item.get("text"):
+                return item["text"]
+    for item in translations:
+        if item.get("text"):
+            return item["text"]
+    return None
+
+
+def _enum_name(value: Any) -> Optional[str]:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        return value
+    return str(value)
+
+
+def _format_timestamp(value: Any) -> Optional[str]:
+    if value in (None, "", 0, "0"):
+        return None
+    try:
+        return (
+            datetime.fromtimestamp(int(value), tz=timezone.utc)
+            .astimezone(TIMEZONE)
+            .isoformat()
+        )
+    except (TypeError, ValueError, OSError):
+        return str(value)
+
+
+def _route_short_name_map() -> Dict[str, str]:
+    try:
+        routes_file = GTFS_DIR / "routes.txt"
+        if not routes_file.exists():
+            return {}
+        route_map = {}
+        for route in iter_gtfs_file(routes_file):
+            route_id = strip_delijn_id_prefix(route.get("route_id", ""))
+            short_name = route.get("route_short_name")
+            if route_id and short_name:
+                route_map[route_id] = short_name
+        return route_map
+    except Exception as exc:
+        logger.warning("Could not load De Lijn route map from GTFS: %s", exc)
+        return {}
+
+
+def _stop_name_map() -> Dict[str, str]:
+    try:
+        stops_file = GTFS_DIR / "stops.txt"
+        if not stops_file.exists():
+            return {}
+        stop_map = {}
+        for stop in iter_gtfs_file(stops_file):
+            stop_id = normalize_delijn_stop_id(stop.get("stop_id"))
+            stop_name = stop.get("stop_name")
+            if stop_id and stop_name:
+                stop_map[stop_id] = stop_name
+        return stop_map
+    except Exception as exc:
+        logger.warning("Could not load De Lijn stop map from GTFS: %s", exc)
+        return {}
+
+
+def _extract_informed_entities(alert: Dict[str, Any]) -> List[Dict[str, Any]]:
+    entities = alert.get("informedEntity") or alert.get("informed_entity") or []
+    if isinstance(entities, dict):
+        return [entities]
+    return entities
+
+
+def _extract_active_period(alert: Dict[str, Any]) -> Dict[str, Optional[str]]:
+    periods = alert.get("activePeriod") or alert.get("active_period") or []
+    if isinstance(periods, dict):
+        periods = [periods]
+    if not periods:
+        return {"start": None, "end": None}
+    first = periods[0]
+    return {
+        "start": _format_timestamp(first.get("start")),
+        "end": _format_timestamp(first.get("end")),
+    }
+
+
+def _format_belgian_mobility_alerts(
+    feed: Dict[str, Any],
+    route_map: Dict[str, str],
+    stop_map: Dict[str, str],
+    monitored_lines: set[str],
+    monitored_stops: set[str],
+) -> List[Dict]:
+    formatted_messages = []
+    for entity in feed.get("entity", []):
+        alert = entity.get("alert")
+        if not alert:
+            continue
+
+        affected_lines = set()
+        affected_stops = {}
+        for informed_entity in _extract_informed_entities(alert):
+            route_id = strip_delijn_id_prefix(
+                informed_entity.get("routeId") or informed_entity.get("route_id")
+            )
+            stop_id = normalize_delijn_stop_id(
+                informed_entity.get("stopId") or informed_entity.get("stop_id")
+            )
+            if route_id:
+                affected_lines.add(route_map.get(route_id, route_id))
+            if stop_id:
+                affected_stops[stop_id] = stop_map.get(stop_id, stop_id)
+
+        sorted_lines = sorted(
+            affected_lines, key=lambda x: int(x) if str(x).isdigit() else str(x)
+        )
+        sorted_stops = [
+            {"id": stop_id, "name": name, "long_name": name}
+            for stop_id, name in sorted(affected_stops.items())
+        ]
+        title = _translation_text(
+            alert.get("headerText") or alert.get("header_text") or {}
+        )
+        description = _translation_text(
+            alert.get("descriptionText") or alert.get("description_text") or {}
+        )
+
+        formatted_messages.append(
+            {
+                "title": title or description or entity.get("id"),
+                "description": description or title,
+                "period": _extract_active_period(alert),
+                "type": _enum_name(alert.get("effect")) or _enum_name(alert.get("cause")),
+                "reference": entity.get("id"),
+                "affected_lines": sorted_lines,
+                "line_colors": {},
+                "affected_stops": sorted_stops,
+                "affected_days": [],
+                "is_monitored": bool(
+                    monitored_lines.intersection(sorted_lines)
+                    or monitored_stops.intersection(affected_stops.keys())
+                ),
+                "source": "belgian_mobility",
+            }
+        )
+    return formatted_messages
+
+
+async def _get_belgian_mobility_service_messages() -> List[Dict]:
+    """Fetch and format De Lijn GTFS-RT alerts from Belgian Mobility."""
+    if not BELGIAN_MOBILITY_ALERTS_URL:
+        raise RuntimeError("DELIJN_BELGIAN_MOBILITY_ALERTS_URL is not configured")
+
+    await ensure_gtfs_data()
+    route_map = _route_short_name_map()
+    stop_map = _stop_name_map()
+    monitored_lines = set(MONITORED_LINES or [])
+    monitored_stops = {str(stop_id) for stop_id in (STOP_ID or [])}
+
+    async with httpx.AsyncClient(timeout=30.0, follow_redirects=True) as client:
+        response = await client.get(
+            BELGIAN_MOBILITY_ALERTS_URL, headers=_mobility_headers()
+        )
+        response.raise_for_status()
+        feed = response.json()
+
+    formatted_messages = _format_belgian_mobility_alerts(
+        feed, route_map, stop_map, monitored_lines, monitored_stops
+    )
+    for formatted_message in formatted_messages:
+        line_colors = {}
+        for line in formatted_message["affected_lines"]:
+            colors = await get_line_color(line)
+            if colors:
+                line_colors[line] = colors
+        formatted_message["line_colors"] = line_colors
+
+    return formatted_messages
+
+
 service_messages_cache = {}
 
 
 async def get_service_messages() -> List[Dict]:
-    """Get service messages for monitored stops and lines with caching"""
+    """Get service messages for monitored stops and lines with caching."""
+    if _service_alerts_use_belgian_mobility():
+        try:
+            messages = await _get_belgian_mobility_service_messages()
+            cache_until = datetime.now(timezone.utc) + timedelta(
+                seconds=SERVICE_MESSAGE_CACHE_DURATION
+            )
+            await cache_set("service_messages", messages, cache_until)
+            return messages
+        except Exception as exc:
+            logger.warning(
+                "Belgian Mobility De Lijn service alerts failed; "
+                "falling back to legacy: %s",
+                exc,
+            )
+    return await _get_legacy_service_messages()
+
+
+async def _get_legacy_service_messages() -> List[Dict]:
+    """Get service messages from the legacy De Lijn API with caching."""
     cache_key = "service_messages"
 
     # Try to get from cache first
@@ -1376,7 +1788,7 @@ async def ensure_gtfs_data() -> Optional[Path]:
 
     # Verify files after download
     if GTFS_DIR.exists():
-        missing_files = [f for f in GTFS_USED_FILES if not (GTFS_DIR / f).exists()]
+        missing_files = [f for f in _required_gtfs_files() if not (GTFS_DIR / f).exists()]
         if missing_files:
             logger.error(f"After GTFSdownload, still missing files: {missing_files}")
             return None

--- a/app/transit_providers/be/delijn/api.py
+++ b/app/transit_providers/be/delijn/api.py
@@ -6,7 +6,6 @@ from typing import Dict, List, Optional, TypedDict, Any, Union, Tuple, Generator
 from pathlib import Path
 import pandas as pd
 import zipfile
-import niquests as requests
 import pytz
 import inspect
 import logging
@@ -465,25 +464,22 @@ async def get_line_color_from_gtfs(line_number: str) -> Optional[Dict[str, str]]
         if not gtfs_dir:
             return None
 
-        routes_file = gtfs_dir / "routes.txt"
-        if not routes_file.exists():
+        _, route = await get_route_info(gtfs_dir, str(line_number))
+        if not route:
             return None
 
-        for route in iter_gtfs_file(routes_file):
-            if route.get("route_short_name") != str(line_number):
-                continue
-            background = route.get("route_color")
-            text = route.get("route_text_color")
-            if not background:
-                return None
-            color_data = {
-                "text": f"#{text}" if text else "#FFFFFF",
-                "background": f"#{background}",
-                "text_border": f"#{text}" if text else "#FFFFFF",
-                "background_border": f"#{background}",
-            }
-            await cache_set(f"line_color_{line_number}", color_data)
-            return color_data
+        background = route.get("route_color")
+        text = route.get("route_text_color")
+        if not background:
+            return None
+        color_data = {
+            "text": f"#{text}" if text else "#FFFFFF",
+            "background": f"#{background}",
+            "text_border": f"#{text}" if text else "#FFFFFF",
+            "background_border": f"#{background}",
+        }
+        await cache_set(f"line_color_{line_number}", color_data)
+        return color_data
     except Exception as exc:
         logger.error("Error reading line color from GTFS for %s: %s", line_number, exc)
     return None
@@ -872,62 +868,34 @@ async def _download_gtfs_source(source: str, url: str, headers: Dict[str, str]) 
         tmp_zip.unlink()
 
     try:
-        response = requests.get(url, headers=headers, stream=True, timeout=120)
-        response.raise_for_status()
-        total_size = int(response.headers.get("content-length", 0))
-        if total_size:
-            logger.info(
-                "GTFS file size from %s: %.1fMB",
-                source,
-                total_size / (1024 * 1024),
-            )
+        async with httpx.AsyncClient(timeout=120.0, follow_redirects=True) as client:
+            async with client.stream("GET", url, headers=headers) as response:
+                response.raise_for_status()
+                response_headers = dict(response.headers)
+                total_size = int(response.headers.get("content-length", 0))
+                if total_size:
+                    logger.info(
+                        "GTFS file size from %s: %.1fMB",
+                        source,
+                        total_size / (1024 * 1024),
+                    )
 
-        progress = ProgressTracker(total_size) if total_size else None
-        with open(tmp_zip, "wb") as f_zip:
-            for chunk in response.iter_content(chunk_size=1024 * 1024):
-                if chunk:
-                    f_zip.write(chunk)
-                    if progress:
-                        progress.update(len(chunk))
+                progress = ProgressTracker(total_size) if total_size else None
+                with open(tmp_zip, "wb") as f_zip:
+                    async for chunk in response.aiter_bytes(chunk_size=1024 * 1024):
+                        if chunk:
+                            f_zip.write(chunk)
+                            if progress:
+                                progress.update(len(chunk))
 
-        tmp_dir.mkdir(parents=True)
-        with zipfile.ZipFile(tmp_zip, "r") as zip_ref:
-            _safe_extract_zip(zip_ref, tmp_dir)
-
-        if source == "belgian_mobility":
-            normalize_static_gtfs_dir(tmp_dir)
-
-        missing_files = [
-            filename
-            for filename in _required_gtfs_files()
-            if not (tmp_dir / filename).exists()
-        ]
-        if missing_files:
-            logger.error("GTFS download from %s missing files: %s", source, missing_files)
-            return False
-
-        for file in tmp_dir.glob("*"):
-            if file.name not in _required_gtfs_files():
-                file.unlink()
-                logger.debug("Deleted unused GTFS file: %s", file.name)
-
-        if GTFS_DIR.exists():
-            shutil.rmtree(GTFS_DIR)
-        tmp_dir.rename(GTFS_DIR)
-
-        metadata = {
-            "downloaded_at": datetime.now(timezone.utc).isoformat(),
-            "source": source,
-            "source_url": url,
-            "last_modified": response.headers.get("last-modified"),
-            "etag": response.headers.get("etag"),
-        }
-        (CACHE_DIR / "gtfs_metadata.json").write_text(
-            json.dumps(metadata, indent=2), encoding="utf-8"
+        return await asyncio.to_thread(
+            _install_gtfs_archive,
+            source,
+            url,
+            tmp_zip,
+            tmp_dir,
+            response_headers,
         )
-
-        logger.info("GTFS data updated successfully from %s", source)
-        return True
     except Exception as exc:
         logger.error("Error downloading De Lijn GTFS from %s: %s", source, exc)
         return False
@@ -936,6 +904,54 @@ async def _download_gtfs_source(source: str, url: str, headers: Dict[str, str]) 
             tmp_zip.unlink()
         if tmp_dir.exists():
             shutil.rmtree(tmp_dir)
+
+
+def _install_gtfs_archive(
+    source: str,
+    url: str,
+    tmp_zip: Path,
+    tmp_dir: Path,
+    response_headers: Dict[str, str],
+) -> bool:
+    tmp_dir.mkdir(parents=True)
+    with zipfile.ZipFile(tmp_zip, "r") as zip_ref:
+        _safe_extract_zip(zip_ref, tmp_dir)
+
+    if source == "belgian_mobility":
+        normalize_static_gtfs_dir(tmp_dir)
+
+    missing_files = [
+        filename
+        for filename in _required_gtfs_files()
+        if not (tmp_dir / filename).exists()
+    ]
+    if missing_files:
+        logger.error("GTFS download from %s missing files: %s", source, missing_files)
+        return False
+
+    required_files = set(_required_gtfs_files())
+    for file in tmp_dir.glob("*"):
+        if file.name not in required_files:
+            file.unlink()
+            logger.debug("Deleted unused GTFS file: %s", file.name)
+
+    if GTFS_DIR.exists():
+        shutil.rmtree(GTFS_DIR)
+    tmp_dir.rename(GTFS_DIR)
+
+    metadata = {
+        "downloaded_at": datetime.now(timezone.utc).isoformat(),
+        "source": source,
+        "source_url": url,
+        "last_modified": response_headers.get("last-modified"),
+        "etag": response_headers.get("etag"),
+    }
+    (CACHE_DIR / "gtfs_metadata.json").write_text(
+        json.dumps(metadata, indent=2), encoding="utf-8"
+    )
+
+    logger.info("GTFS data updated successfully from %s", source)
+    return True
 
 
 def iter_gtfs_file(file_path: Path) -> Generator[Dict[str, str], None, None]:
@@ -1461,7 +1477,8 @@ def _format_belgian_mobility_alerts(
                 affected_stops[stop_id] = stop_map.get(stop_id, stop_id)
 
         sorted_lines = sorted(
-            affected_lines, key=lambda x: int(x) if str(x).isdigit() else str(x)
+            affected_lines,
+            key=lambda x: (0, int(x)) if str(x).isdigit() else (1, str(x)),
         )
         sorted_stops = [
             {"id": stop_id, "name": name, "long_name": name}

--- a/app/transit_providers/be/delijn/config.py
+++ b/app/transit_providers/be/delijn/config.py
@@ -4,6 +4,7 @@ import os
 from pathlib import Path
 import logging
 from transit_providers.config import get_config, register_provider_config
+from transit_providers.be.mobility import mobility_url
 
 # Get logger
 logger = logging.getLogger("transit_providers.be.delijn")
@@ -26,7 +27,12 @@ DEFAULT_CONFIG = {
     ],  # Example lines - should be set in local.py
     "API_URL": "https://api.delijn.be/DLKernOpenData/api/v1",
     "_AVAILABLE_LANGUAGES": ["nl"],  # De Lijn only provides Dutch content
-    "GTFS_URL": "https://api.delijn.be/gtfs/static/v3/gtfs_transit.zip",
+    "GTFS_STATIC_SOURCE": os.getenv("DELIJN_GTFS_STATIC_SOURCE", "belgian_mobility"),
+    "GTFS_URL": os.getenv(
+        "DELIJN_BELGIAN_MOBILITY_GTFS_STATIC_URL",
+        "https://opendata-discovery-gtfs-static.api.production.belgianmobility.io/api/gtfs/feed/delijn/static",
+    ),
+    "LEGACY_GTFS_URL": "https://api.delijn.be/gtfs/static/v3/gtfs_transit.zip",
     "GTFS_DIR": PROJECT_ROOT / "cache" / "delijn" / "gtfs",
     "CACHE_DIR": PROJECT_ROOT / "cache" / "delijn",
     "RATE_LIMIT_DELAY": 0.5,  # seconds between API calls
@@ -38,6 +44,21 @@ DEFAULT_CONFIG = {
     "GTFS_REALTIME_API_KEY": os.getenv(
         "DELIJN_GTFS_REALTIME_API_KEY"
     ),  # API key for GTFS-RT data
+    "SERVICE_ALERTS_SOURCE": os.getenv(
+        "DELIJN_SERVICE_ALERTS_SOURCE", "belgian_mobility"
+    ),
+    "BELGIAN_MOBILITY_ALERTS_URL": os.getenv(
+        "DELIJN_BELGIAN_MOBILITY_ALERTS_URL",
+        mobility_url("/api/gtfs/feed/delijn/rt/alert"),
+    ),
+    "BELGIAN_MOBILITY_TRIP_UPDATES_URL": os.getenv(
+        "DELIJN_BELGIAN_MOBILITY_TRIP_UPDATES_URL",
+        mobility_url("/api/gtfs/feed/delijn/rt/trip-update"),
+    ),
+    "VEHICLE_POSITIONS_SOURCE": os.getenv("DELIJN_VEHICLE_POSITIONS_SOURCE", "legacy"),
+    "BELGIAN_MOBILITY_VEHICLE_POSITIONS_URL": os.getenv(
+        "DELIJN_BELGIAN_MOBILITY_VEHICLE_POSITIONS_URL"
+    ),
     "GTFS_USED_FILES": ["stops.txt", "routes.txt", "trips.txt", "shapes.txt"],
 }
 

--- a/app/transit_providers/be/delijn/docs/delijn_data_processing.md
+++ b/app/transit_providers/be/delijn/docs/delijn_data_processing.md
@@ -73,7 +73,7 @@ Example vehicle position data:
 - Belgian Mobility GTFS IDs are normalized back to the app's existing De Lijn ID shape. For example, `gs:delijn:307250` becomes `307250`, and `gr:delijn:10010` becomes `10010`.
 - Service alerts now default to Belgian Mobility GTFS-RT alerts and fall back to the legacy De Lijn `storingen` / `omleidingen` endpoints.
 - Vehicle positions remain legacy-only. The Belgian Mobility De Lijn realtime endpoints currently expose TripUpdates and Alerts; TripUpdates are useful for arrival/delay work, but they are not equivalent to the legacy vehicle-position feed.
-- Live check on 2026-06-21: the Belgian Mobility static De Lijn feed returned `gtfs-delijn-bmc-latest.zip` with `Content-Length: 243075546` and `Last-Modified: Sun, 21 Jun 2026 03:09:29 GMT`. The APIM `trip-update` and `alert` paths exist but require quota/auth handling; guessed `vehicle-position` and `vehicle-positions` paths returned 404.
+- Authenticated live check on 2026-06-21 using the Belgian Mobility subscription headers: the Belgian Mobility static De Lijn feed returned HTTP 200, `Content-Type: application/zip`, `Content-Length: 243075546`, and ZIP magic `PK`. APIM `alert` returned HTTP 200 with 384 alert entities. APIM `trip-update` returned HTTP 200 with 1,969 TripUpdate entities and 0 VehiclePosition entities. Guessed APIM `vehicle-position` and `vehicle-positions` paths both returned 404.
 
 ## Frontend Display
 

--- a/app/transit_providers/be/delijn/docs/delijn_data_processing.md
+++ b/app/transit_providers/be/delijn/docs/delijn_data_processing.md
@@ -67,6 +67,14 @@ Example vehicle position data:
 - Direction is used as a fallback if headsign is not available
 - Vehicles are only shown if they belong to our monitored lines
 
+## Belgian Mobility Migration Notes
+
+- Static GTFS now defaults to Belgian Mobility and falls back to the legacy De Lijn static GTFS endpoint when the Belgian Mobility download fails.
+- Belgian Mobility GTFS IDs are normalized back to the app's existing De Lijn ID shape. For example, `gs:delijn:307250` becomes `307250`, and `gr:delijn:10010` becomes `10010`.
+- Service alerts now default to Belgian Mobility GTFS-RT alerts and fall back to the legacy De Lijn `storingen` / `omleidingen` endpoints.
+- Vehicle positions remain legacy-only. The Belgian Mobility De Lijn realtime endpoints currently expose TripUpdates and Alerts; TripUpdates are useful for arrival/delay work, but they are not equivalent to the legacy vehicle-position feed.
+- Live check on 2026-06-21: the Belgian Mobility static De Lijn feed returned `gtfs-delijn-bmc-latest.zip` with `Content-Length: 243075546` and `Last-Modified: Sun, 21 Jun 2026 03:09:29 GMT`. The APIM `trip-update` and `alert` paths exist but require quota/auth handling; guessed `vehicle-position` and `vehicle-positions` paths returned 404.
+
 ## Frontend Display
 
 The frontend receives the processed vehicle data and displays:
@@ -113,4 +121,3 @@ From this, we can see that:
 |----------|------------|---------|---------------|-----------------|--------------|-----------|-----------|
 | 3118_2VR3128-19_0 | 1956 | 3118_101_404_2VR3128-19_3288-0863mod2951_1433_1034d2511267a1e815e372681f1e12b05b4b5c774f7c15b855a68ba7a044d1c8 | Brussel Zuid - Itterbeek - `Schepdaal` | 101 | `0` | 3288-0863mod2951 | 3118404 |
 | 3118_2VR3128-19_1 | 1612 | 3118_104_406_2VR3128-19_3288-0863mod2951_1581_c1db6f3129dc61c84f378eeca36d005d31a16fe7d4c45dec41ab0ad8a8576b7b | Schepdaal - Itterbeek - Brussel Zuid | 104 | 1 | 3288-0863mod2951 | 3118406 |
-

--- a/app/transit_providers/be/delijn/ids.py
+++ b/app/transit_providers/be/delijn/ids.py
@@ -63,16 +63,28 @@ def _normalize_static_gtfs_file(path: Path, columns: set[str]) -> None:
         if not reader.fieldnames:
             return
 
+        existing_columns = columns.intersection(reader.fieldnames)
+        if not existing_columns:
+            return
+
         try:
+            changed = False
             with tmp_path.open("w", encoding="utf-8", newline="") as out_file:
                 writer = csv.DictWriter(out_file, fieldnames=reader.fieldnames)
                 writer.writeheader()
                 for row in reader:
-                    for column in columns:
-                        if row.get(column):
-                            row[column] = strip_delijn_id_prefix(row[column])
+                    for column in existing_columns:
+                        value = row[column]
+                        if value:
+                            normalized = strip_delijn_id_prefix(value)
+                            if normalized != value:
+                                row[column] = normalized
+                                changed = True
                     writer.writerow(row)
-            tmp_path.replace(path)
+            if changed:
+                tmp_path.replace(path)
+            else:
+                tmp_path.unlink()
         except Exception:
             if tmp_path.exists():
                 tmp_path.unlink()

--- a/app/transit_providers/be/delijn/ids.py
+++ b/app/transit_providers/be/delijn/ids.py
@@ -1,0 +1,79 @@
+"""De Lijn identifier normalization helpers."""
+
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+DELIJN_ID_PREFIXES = (
+    "gt:delijn:",
+    "gs:delijn:",
+    "gr:delijn:",
+    "gc:delijn:",
+    "gw:delijn:",
+    "delijn:",
+)
+
+GTFS_ID_COLUMNS = {
+    "agency.txt": {"agency_id"},
+    "calendar.txt": {"service_id"},
+    "calendar_dates.txt": {"service_id"},
+    "routes.txt": {"agency_id", "route_id"},
+    "stop_times.txt": {"stop_id", "trip_id"},
+    "stops.txt": {"parent_station", "stop_id"},
+    "transfers.txt": {
+        "from_route_id",
+        "from_stop_id",
+        "from_trip_id",
+        "to_route_id",
+        "to_stop_id",
+        "to_trip_id",
+    },
+    "trips.txt": {"block_id", "route_id", "service_id", "shape_id", "trip_id"},
+}
+
+
+def strip_delijn_id_prefix(value: str | None) -> str:
+    """Strip Belgian Mobility De Lijn prefixes while leaving legacy IDs unchanged."""
+    if not value:
+        return ""
+    for prefix in DELIJN_ID_PREFIXES:
+        if value.startswith(prefix):
+            return value[len(prefix) :]
+    return value
+
+
+def normalize_delijn_stop_id(value: str | None) -> str:
+    """Normalize a De Lijn stop ID to the legacy numeric stop ID shape."""
+    return strip_delijn_id_prefix(value)
+
+
+def normalize_static_gtfs_dir(gtfs_dir: Path) -> None:
+    """Normalize Belgian Mobility GTFS IDs in-place to this provider's legacy ID shape."""
+    for filename, columns in GTFS_ID_COLUMNS.items():
+        path = gtfs_dir / filename
+        if path.exists():
+            _normalize_static_gtfs_file(path, columns)
+
+
+def _normalize_static_gtfs_file(path: Path, columns: set[str]) -> None:
+    tmp_path = path.with_suffix(path.suffix + ".tmp")
+    with path.open("r", encoding="utf-8", newline="") as in_file:
+        reader = csv.DictReader(in_file)
+        if not reader.fieldnames:
+            return
+
+        try:
+            with tmp_path.open("w", encoding="utf-8", newline="") as out_file:
+                writer = csv.DictWriter(out_file, fieldnames=reader.fieldnames)
+                writer.writeheader()
+                for row in reader:
+                    for column in columns:
+                        if row.get(column):
+                            row[column] = strip_delijn_id_prefix(row[column])
+                    writer.writerow(row)
+            tmp_path.replace(path)
+        except Exception:
+            if tmp_path.exists():
+                tmp_path.unlink()
+            raise

--- a/app/transit_providers/be/delijn/test_mobility.py
+++ b/app/transit_providers/be/delijn/test_mobility.py
@@ -44,6 +44,23 @@ def test_normalize_static_gtfs_dir(tmp_path):
     ]
 
 
+def test_normalize_static_gtfs_file_leaves_unchanged_file_in_place(tmp_path):
+    stops = tmp_path / "stops.txt"
+    with stops.open("w", encoding="utf-8", newline="") as out_file:
+        writer = csv.DictWriter(out_file, fieldnames=["stop_id", "parent_station"])
+        writer.writeheader()
+        writer.writerow({"stop_id": "307250", "parent_station": ""})
+
+    before_mtime = stops.stat().st_mtime_ns
+    delijn_ids.normalize_static_gtfs_dir(tmp_path)
+
+    assert stops.stat().st_mtime_ns == before_mtime
+    assert not (tmp_path / "stops.txt.tmp").exists()
+    assert list(csv.DictReader(stops.open(encoding="utf-8"))) == [
+        {"stop_id": "307250", "parent_station": ""}
+    ]
+
+
 def test_format_belgian_mobility_alerts_maps_entities_to_legacy_shape():
     feed = {
         "entity": [
@@ -102,3 +119,30 @@ def test_format_belgian_mobility_alerts_maps_entities_to_legacy_shape():
             "source": "belgian_mobility",
         }
     ]
+
+
+def test_format_belgian_mobility_alerts_sorts_mixed_lines():
+    feed = {
+        "entity": [
+            {
+                "id": "alert-1",
+                "alert": {
+                    "informedEntity": [
+                        {"routeId": "gr:delijn:10010"},
+                        {"routeId": "gr:delijn:10002"},
+                        {"routeId": "gr:delijn:N1"},
+                    ],
+                },
+            }
+        ]
+    }
+
+    messages = delijn_api._format_belgian_mobility_alerts(
+        feed,
+        route_map={"10010": "10", "10002": "2"},
+        stop_map={},
+        monitored_lines=set(),
+        monitored_stops=set(),
+    )
+
+    assert messages[0]["affected_lines"] == ["2", "10", "N1"]

--- a/app/transit_providers/be/delijn/test_mobility.py
+++ b/app/transit_providers/be/delijn/test_mobility.py
@@ -1,0 +1,104 @@
+import os
+import sys
+import csv
+from pathlib import Path
+
+_APP_DIR = Path(__file__).resolve().parents[3]
+os.environ.setdefault("PROJECT_ROOT", str(_APP_DIR))
+if str(_APP_DIR) not in sys.path:
+    sys.path.insert(0, str(_APP_DIR))
+
+from transit_providers.be.delijn import api as delijn_api
+from transit_providers.be.delijn import ids as delijn_ids
+
+
+def test_strip_delijn_id_prefix():
+    assert delijn_ids.strip_delijn_id_prefix("gs:delijn:307250") == "307250"
+    assert delijn_ids.strip_delijn_id_prefix("gr:delijn:10010") == "10010"
+    assert delijn_ids.strip_delijn_id_prefix("gt:delijn:trip-1") == "trip-1"
+    assert delijn_ids.strip_delijn_id_prefix("307250") == "307250"
+
+
+def test_normalize_static_gtfs_dir(tmp_path):
+    stops = tmp_path / "stops.txt"
+    with stops.open("w", encoding="utf-8", newline="") as out_file:
+        writer = csv.DictWriter(out_file, fieldnames=["stop_id", "parent_station"])
+        writer.writeheader()
+        writer.writerow(
+            {"stop_id": "gs:delijn:307250", "parent_station": "gs:delijn:parent"}
+        )
+
+    routes = tmp_path / "routes.txt"
+    with routes.open("w", encoding="utf-8", newline="") as out_file:
+        writer = csv.DictWriter(out_file, fieldnames=["agency_id", "route_id"])
+        writer.writeheader()
+        writer.writerow({"agency_id": "delijn", "route_id": "gr:delijn:10010"})
+
+    delijn_ids.normalize_static_gtfs_dir(tmp_path)
+
+    assert list(csv.DictReader(stops.open(encoding="utf-8"))) == [
+        {"stop_id": "307250", "parent_station": "parent"}
+    ]
+    assert list(csv.DictReader(routes.open(encoding="utf-8"))) == [
+        {"agency_id": "delijn", "route_id": "10010"}
+    ]
+
+
+def test_format_belgian_mobility_alerts_maps_entities_to_legacy_shape():
+    feed = {
+        "entity": [
+            {
+                "id": "alert-1",
+                "alert": {
+                    "activePeriod": [{"start": "1766602800", "end": "1766606400"}],
+                    "effect": "DETOUR",
+                    "headerText": {
+                        "translation": [
+                            {"language": "nl", "text": "Omleiding op lijn 1"}
+                        ]
+                    },
+                    "descriptionText": {
+                        "translation": [
+                            {"language": "nl", "text": "Halte tijdelijk niet bediend"}
+                        ]
+                    },
+                    "informedEntity": [
+                        {"routeId": "gr:delijn:10010", "stopId": "gs:delijn:307250"}
+                    ],
+                },
+            }
+        ]
+    }
+
+    messages = delijn_api._format_belgian_mobility_alerts(
+        feed,
+        route_map={"10010": "1"},
+        stop_map={"307250": "Brussel Zuid perron 10"},
+        monitored_lines={"1"},
+        monitored_stops=set(),
+    )
+
+    assert messages == [
+        {
+            "title": "Omleiding op lijn 1",
+            "description": "Halte tijdelijk niet bediend",
+            "period": {
+                "start": "2025-12-24T20:00:00+01:00",
+                "end": "2025-12-24T21:00:00+01:00",
+            },
+            "type": "DETOUR",
+            "reference": "alert-1",
+            "affected_lines": ["1"],
+            "line_colors": {},
+            "affected_stops": [
+                {
+                    "id": "307250",
+                    "name": "Brussel Zuid perron 10",
+                    "long_name": "Brussel Zuid perron 10",
+                }
+            ],
+            "affected_days": [],
+            "is_monitored": True,
+            "source": "belgian_mobility",
+        }
+    ]

--- a/readme.md
+++ b/readme.md
@@ -117,14 +117,28 @@ Alternatively, you can run individual components:
 
 ### De Lijn API (Belgium)
 
-1. Visit the [De Lijn Developer Portal](https://data.delijn.be/)
-2. Create an account
-3. Subscribe to both:
-   - "Open Data Free Subscribe Here" 
-   - "De Lijn GTFS Realtime"
-   - "De Lijn GTFS Static"
-4. Add the keys to your `.env` file (as DELIJN_API_KEY, DELIJN_GTFS_STATIC_API_KEY, and 
-DELIJN_GTFS_REALTIME_API_KEY)
+De Lijn static GTFS and service alerts use Belgian Mobility by default. Static GTFS is downloaded from the Belgian Mobility GTFS static endpoint and normalized back to the existing De Lijn stop, route, trip, and shape ID format used by the app.
+
+1. Visit https://api-management-opendata-production.developer.azure-api.net/
+2. Create an account and subscribe to the Standard product.
+3. Add the primary or secondary key to `.env` as `MOBILITY_API_PRIMARY_KEY` or `MOBILITY_API_SECONDARY_KEY`.
+4. Keep the De Lijn Developer Portal keys for legacy fallback and vehicle positions:
+   - `DELIJN_API_KEY`
+   - `DELIJN_GTFS_STATIC_API_KEY`
+   - `DELIJN_GTFS_REALTIME_API_KEY`
+
+Vehicle positions remain on De Lijn's legacy GTFS realtime endpoint. Belgian Mobility De Lijn TripUpdates and ServiceAlerts are not a replacement for vehicle positions unless a dedicated VehiclePositions endpoint is configured later.
+
+Optional overrides:
+
+```env
+DELIJN_GTFS_STATIC_SOURCE=belgian_mobility
+DELIJN_SERVICE_ALERTS_SOURCE=belgian_mobility
+DELIJN_VEHICLE_POSITIONS_SOURCE=legacy
+DELIJN_BELGIAN_MOBILITY_GTFS_STATIC_URL=https://opendata-discovery-gtfs-static.api.production.belgianmobility.io/api/gtfs/feed/delijn/static
+DELIJN_BELGIAN_MOBILITY_ALERTS_URL=https://api-management-opendata-production.azure-api.net/api/gtfs/feed/delijn/rt/alert
+DELIJN_BELGIAN_MOBILITY_TRIP_UPDATES_URL=https://api-management-opendata-production.azure-api.net/api/gtfs/feed/delijn/rt/trip-update
+```
 
 ### SNCB (Belgium)
 


### PR DESCRIPTION
## Summary

- Make Belgian Mobility the primary De Lijn static GTFS source, with legacy De Lijn static GTFS fallback.
- Normalize Belgian Mobility De Lijn GTFS IDs back to the app's existing stop, route, trip, service, and shape ID shape.
- Fetch De Lijn service alerts from Belgian Mobility GTFS-RT alerts by default, falling back to legacy `storingen` / `omleidingen`.
- Keep vehicle positions legacy-only and expose a `realtime_sources` status endpoint documenting why TripUpdates are not a VehiclePositions replacement.
- Update env templates, Docker docs, provider docs, README, and changelog for the next release.
- Address review feedback by streaming the large GTFS download asynchronously, offloading zip extraction/normalization to a worker thread, using cached route info for GTFS line colors, making mixed line sorting type-safe, and avoiding unnecessary GTFS normalization rewrites.

## Authenticated endpoint proof

Checked on 2026-06-21 with the Belgian Mobility key from the main checkout environment. The key was used only as request headers and was not printed or committed.

- Belgian Mobility static De Lijn feed: HTTP 200, `Content-Type: application/zip`, `Content-Length: 243075546`, first bytes `PK`.
- APIM `delijn/rt/alert`: HTTP 200, `Content-Type: application/json; charset=utf-8`, 384 alert entities, 0 tripUpdate entities, 0 vehicle entities.
- APIM `delijn/rt/trip-update`: HTTP 200, `Content-Type: application/json; charset=utf-8`, 1,969 TripUpdate entities, 0 alert entities, 0 vehicle entities.
- APIM `delijn/rt/vehicle-position`: HTTP 404.
- APIM `delijn/rt/vehicle-positions`: HTTP 404.

Conclusion: Belgian Mobility is usable for De Lijn static GTFS and service alerts. It does not currently provide comparable vehicle-position data, so vehicle positions remain legacy-only.

## Validation

- `.venv/bin/python -m py_compile app/transit_providers/be/delijn/api.py app/transit_providers/be/delijn/config.py app/transit_providers/be/delijn/ids.py app/transit_providers/be/delijn/__init__.py app/config/default.py app/config/local.py.example`
- `.venv/bin/python -m pytest app/transit_providers/test_config_schema.py app/transit_providers/be/delijn/test_mobility.py app/transit_providers/be/test_mobility.py` -> 13 passed
- `git diff --check`

Broader `app/transit_providers/test_config_integration.py` was not used as a gating check because it currently requires `pytest-asyncio` which is not in `requirements.txt`, and it has existing STIB config roundtrip failures unrelated to this change.