### PR TITLE
Fix CodeQL security boundaries

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+.git
+.gitignore
+.dockerignore
+.env
+.pytest_cache/
+.venv/
+venv/
+**/__pycache__/
+**/*.py[cod]
+app/config/local.py
+cache/
+downloads/
+logs/

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -13,6 +13,9 @@ env:
   REGISTRY: ghcr.io
   IMAGE_NAME: ${{ github.repository }}
 
+permissions:
+  contents: read
+
 jobs:
   docker-test:
     runs-on: ubuntu-latest
@@ -48,6 +51,13 @@ jobs:
           tags: brussels_transit-web:test
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new,mode=max
+
+      - name: Run security regression tests
+        run: |
+          docker run --rm --entrypoint python brussels_transit-web:test \
+            -m pytest -q \
+            app/test_security_utils.py \
+            app/schedule_explorer/frontend/test_security_regressions.py
 
       - name: Move cache
         run: |
@@ -159,4 +169,4 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
-          cache-to: type=gha,mode=max 
+          cache-to: type=gha,mode=max

--- a/app/main.py
+++ b/app/main.py
@@ -21,9 +21,15 @@ from inspect import signature, Parameter
 import inspect
 import logging
 from flask import jsonify
-from transit_providers import PROVIDERS, get_provider_from_path
+from transit_providers import PROVIDERS, get_provider_path
 from transit_providers.config import canonical_provider_name
 from config import get_config
+from security_utils import (
+    PROVIDER_ID_PATTERN,
+    build_schedule_explorer_redirect_url,
+    is_safe_static_path,
+    resolve_provider_asset_directory,
+)
 from dataclasses import asdict
 import os
 from pathlib import Path
@@ -33,7 +39,6 @@ from functools import wraps
 from transit_providers.config import get_provider_config
 from functools import lru_cache
 import niquests as requests
-import re
 import socket
 import psutil
 
@@ -59,9 +64,6 @@ CORS(
 # Proxy configuration - place at the start to handle matching routes before legacy endpoints
 SCHEDULE_EXPLORER_PORT = get_config("SCHEDULE_EXPLORER_PORT", "8000")
 SCHEDULE_EXPLORER_HOST = get_config("SCHEDULE_EXPLORER_HOST", "localhost")
-
-# Regular expression to match provider-id format (e.g., "abc-1234")
-PROVIDER_ID_PATTERN = re.compile(r"^[a-zA-Z]+-\d+$")
 
 FILTER_VEHICLES = True
 
@@ -559,57 +561,7 @@ def validate_static_path(base_dir: str, filename: str, allowed_extensions: set) 
     Returns:
         bool: True if path is valid, False otherwise
     """
-    if not filename or ".." in filename:
-        return False
-
-    # Get file extension
-    ext = os.path.splitext(filename)[1].lower()
-    if ext not in allowed_extensions:
-        return False
-
-    # Construct absolute paths
-    base_path = os.path.abspath(base_dir)
-    file_path = os.path.abspath(os.path.join(base_dir, filename))
-
-    # Check if the file path is within the base directory
-    if not file_path.startswith(base_path):
-        return False
-
-    # Check if file exists
-    if not os.path.isfile(file_path):
-        return False
-
-    return True
-
-
-def is_valid_provider_path(provider_path: str) -> bool:
-    """Validate provider path structure.
-
-    Args:
-        provider_path: The provider path to validate (e.g. 'be/stib')
-
-    Returns:
-        bool: True if path is valid, False otherwise
-    """
-    # Only allow alphanumeric characters, forward slashes, and underscores
-    import re
-
-    if not re.match(r"^[a-zA-Z0-9/_-]+$", provider_path):
-        return False
-
-    # No double slashes or leading/trailing slashes
-    if (
-        "//" in provider_path
-        or provider_path.startswith("/")
-        or provider_path.endswith("/")
-    ):
-        return False
-
-    # Maximum two path components (e.g. 'be/stib')
-    if len(provider_path.split("/")) > 2:
-        return False
-
-    return True
+    return is_safe_static_path(base_dir, filename, allowed_extensions)
 
 
 def get_static_provider_dir(provider_path: str, asset_type: str) -> str:
@@ -622,30 +574,24 @@ def get_static_provider_dir(provider_path: str, asset_type: str) -> str:
     Returns:
         str: The absolute path to the static provider directory
     """
-    # Validate provider path structure
-    if not is_valid_provider_path(provider_path):
-        abort(403)
-
-    # Get and validate provider
-    provider = get_provider_from_path(provider_path)
-    if not provider or provider not in PROVIDERS:
+    registered_paths = {
+        path: path
+        for provider_name in PROVIDERS
+        if (path := get_provider_path(provider_name))
+    }
+    try:
+        return str(
+            resolve_provider_asset_directory(
+                Path(app.root_path) / "transit_providers",
+                provider_path,
+                asset_type,
+                registered_paths,
+            )
+        )
+    except KeyError:
         abort(404)
-
-    # Only allow js and css directories
-    if asset_type not in {"js", "css"}:
+    except ValueError:
         abort(403)
-
-    # Construct and validate the absolute provider directory path
-    provider_dir = os.path.abspath(
-        os.path.join("transit_providers", provider_path, asset_type)
-    )
-    base_dir = os.path.abspath("transit_providers")
-
-    # Ensure the provider directory is within the base directory
-    if not provider_dir.startswith(base_dir):
-        abort(403)
-
-    return provider_dir
 
 
 @app.route("/transit_providers/<path:provider_path>/js/<path:filename>")
@@ -725,23 +671,19 @@ async def provider_endpoint(provider, endpoint, param1=None, param2=None):
     )
 
     try:
-        # First check if this is a provider with a dash (e.g., mdb-1234)
-        if "-" in provider:
-            # Build the redirect URL
-            schedule_explorer_url = f"http://{SCHEDULE_EXPLORER_HOST}:{SCHEDULE_EXPLORER_PORT}"
-            subpath = endpoint
-            if param1:
-                subpath = f"{subpath}/{param1}"
-            if param2:
-                subpath = f"{subpath}/{param2}"
-            url = f"{schedule_explorer_url}/api/{provider}/{subpath}"
-            
-            # Add query parameters
-            params = request.args.to_dict()
-            if params:
-                url += "?" + "&".join(f"{k}={v}" for k, v in params.items())
-            
-            # Redirect to the schedule explorer
+        # Mobility Database provider IDs are handled by the Schedule Explorer.
+        if PROVIDER_ID_PATTERN.fullmatch(provider):
+            path_parameters = tuple(
+                value for value in (param1, param2) if value is not None
+            )
+            url = build_schedule_explorer_redirect_url(
+                SCHEDULE_EXPLORER_HOST,
+                SCHEDULE_EXPLORER_PORT,
+                provider,
+                endpoint,
+                path_parameters,
+                request.args.to_dict(),
+            )
             return redirect(url)
 
         original_provider = provider

--- a/app/main.py
+++ b/app/main.py
@@ -27,7 +27,7 @@ from config import get_config
 from security_utils import (
     PROVIDER_ID_PATTERN,
     build_schedule_explorer_redirect_url,
-    is_safe_static_path,
+    has_allowed_static_extension,
     resolve_provider_asset_directory,
 )
 from dataclasses import asdict
@@ -550,18 +550,17 @@ def get_provider_assets(provider):
     return jsonify(provider_instance.get_assets())
 
 
-def validate_static_path(base_dir: str, filename: str, allowed_extensions: set) -> bool:
-    """Validate a static file path for security.
+def validate_static_filename(filename: str, allowed_extensions: set) -> bool:
+    """Validate a static filename extension before Flask serves it.
 
     Args:
-        base_dir: The base directory to serve files from
         filename: The requested filename
         allowed_extensions: Set of allowed file extensions
 
     Returns:
-        bool: True if path is valid, False otherwise
+        bool: True if the extension is allowed, False otherwise
     """
-    return is_safe_static_path(base_dir, filename, allowed_extensions)
+    return has_allowed_static_extension(filename, allowed_extensions)
 
 
 def get_static_provider_dir(provider_path: str, asset_type: str) -> str:
@@ -600,7 +599,7 @@ def serve_provider_js(provider_path, filename):
     provider_dir = get_static_provider_dir(provider_path, "js")
 
     # Validate file path
-    if not validate_static_path(provider_dir, filename, {".js"}):
+    if not validate_static_filename(filename, {".js"}):
         abort(403)
 
     return send_from_directory(
@@ -614,7 +613,7 @@ def serve_provider_css(provider_path, filename):
     provider_dir = get_static_provider_dir(provider_path, "css")
 
     # Validate file path
-    if not validate_static_path(provider_dir, filename, {".css"}):
+    if not validate_static_filename(filename, {".css"}):
         abort(403)
 
     return send_from_directory(provider_dir, filename, mimetype="text/css")
@@ -623,7 +622,7 @@ def serve_provider_css(provider_path, filename):
 @app.route("/static/css/<path:filename>")
 def serve_static_css(filename):
     # Validate file path
-    if not validate_static_path("static/css", filename, {".css"}):
+    if not validate_static_filename(filename, {".css"}):
         abort(403)
 
     return send_from_directory("static/css", filename, mimetype="text/css")
@@ -633,7 +632,7 @@ def serve_static_css(filename):
 def serve_static_core_js(filename):
     """Serve core JavaScript files"""
     # Validate file path
-    if not validate_static_path("templates/js/core", filename, {".js"}):
+    if not validate_static_filename(filename, {".js"}):
         abort(403)
 
     return send_from_directory(
@@ -645,7 +644,7 @@ def serve_static_core_js(filename):
 def serve_static_config_js(filename):
     """Serve config JavaScript files"""
     # Validate file path
-    if not validate_static_path("templates/js/config", filename, {".js"}):
+    if not validate_static_filename(filename, {".js"}):
         abort(403)
 
     return send_from_directory(

--- a/app/schedule_explorer/frontend/js/app.js
+++ b/app/schedule_explorer/frontend/js/app.js
@@ -44,7 +44,7 @@ async function fetchWithRetry(url, options = {}, retries = 3) {
             console.log(`Successful response from ${url}`);
             return response;
         } catch (error) {
-            console.error(`Error fetching ${url}:`, error);
+            console.error('Error fetching URL: %s', url, error);
             if (i === retries - 1) throw error;
             // Wait before retrying (exponential backoff)
             const delay = Math.pow(2, i) * 1000;

--- a/app/schedule_explorer/frontend/js/stop_explorer.js
+++ b/app/schedule_explorer/frontend/js/stop_explorer.js
@@ -34,7 +34,7 @@ function getStopColor(stopId) {
 
 // Function to escape HTML special characters
 function escapeHtml(unsafe) {
-    return unsafe
+    return String(unsafe)
         .replace(/&/g, "&amp;")
         .replace(/</g, "&lt;")
         .replace(/>/g, "&gt;")
@@ -359,6 +359,8 @@ async function loadAllRoutes() {
     }
 
     try {
+        const safeProviderId = escapeHtml(encodeURIComponent(providerSelect.value));
+
         // Get routes for each stop, reusing data if available
         const results = Array.from(selectedStops.entries()).map(([stopId, stopData]) => {
             return {
@@ -432,11 +434,11 @@ async function loadAllRoutes() {
                                                 ).join(', ')}
                                             </div>
                                             <div class="mt-2">
-                                                <a href="${API_BASE_URL}/api/${providerSelect.value}/stops/${stopId}/waiting_times?route_id=${route.route_id}&limit=10"
+                                                <a href="${API_BASE_URL}/api/${safeProviderId}/stops/${stopId}/waiting_times?route_id=${route.route_id}&limit=10"
                                                    target="_blank" class="btn btn-sm btn-outline-primary me-2">
                                                     View waiting times (json)
                                                 </a>
-                                                <a href="index.html?from=${stopId}&to=${route.terminus_stop_id}&provider=${providerSelect.value}&condensed_view=true&show_stop_ids=true"
+                                                <a href="index.html?from=${stopId}&to=${route.terminus_stop_id}&provider=${safeProviderId}&condensed_view=true&show_stop_ids=true"
                                                    target="_blank" class="btn btn-sm btn-outline-secondary">
                                                     View full route
                                                 </a>

--- a/app/schedule_explorer/frontend/test_security_regressions.py
+++ b/app/schedule_explorer/frontend/test_security_regressions.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+
+
+FRONTEND_JS = Path(__file__).parent / "js"
+
+
+def test_fetch_error_uses_a_constant_console_format_string():
+    source = (FRONTEND_JS / "app.js").read_text(encoding="utf-8")
+
+    assert "console.error('Error fetching URL: %s', url, error);" in source
+    assert "console.error(`Error fetching ${url}:`, error);" not in source
+
+
+def test_stop_explorer_encodes_dom_provider_value_before_html_rendering():
+    source = (FRONTEND_JS / "stop_explorer.js").read_text(encoding="utf-8")
+    render_start = source.index("routesContainer.innerHTML = results.map")
+    render_end = source.index("} catch (error)", render_start)
+    render_source = source[render_start:render_end]
+
+    assert (
+        "const safeProviderId = escapeHtml(encodeURIComponent(providerSelect.value));"
+        in source
+    )
+    assert render_source.count("${safeProviderId}") == 2
+    assert "${providerSelect.value}" not in render_source

--- a/app/security_utils.py
+++ b/app/security_utils.py
@@ -1,0 +1,106 @@
+"""Security boundaries shared by the legacy Flask application."""
+
+import re
+from pathlib import Path
+from typing import Mapping, Optional, Tuple, Union
+from urllib.parse import quote, urlencode, urlsplit, urlunsplit
+
+
+PROVIDER_ID_PATTERN = re.compile(r"^[a-zA-Z]+-\d+$")
+ALLOWED_PROVIDER_ASSET_TYPES = {"css", "js"}
+
+
+def build_schedule_explorer_redirect_url(
+    host: str,
+    port: Union[int, str],
+    provider: str,
+    endpoint: str,
+    path_parameters: Tuple[str, ...] = (),
+    query_parameters: Optional[Mapping[str, str]] = None,
+) -> str:
+    """Build a redirect whose origin comes only from trusted configuration."""
+    if not PROVIDER_ID_PATTERN.fullmatch(provider):
+        raise ValueError("Invalid Mobility Database provider ID")
+
+    configured_host = str(host).strip()
+    if (
+        not configured_host
+        or any(character.isspace() for character in configured_host)
+        or any(character in configured_host for character in "/?#@\\")
+    ):
+        raise ValueError("Invalid Schedule Explorer host")
+
+    hostname = configured_host
+    if hostname.startswith("[") and hostname.endswith("]"):
+        hostname = hostname[1:-1]
+    url_host = f"[{hostname}]" if ":" in hostname else hostname
+
+    configured_port = int(port)
+    if not 1 <= configured_port <= 65535:
+        raise ValueError("Invalid Schedule Explorer port")
+
+    components = (provider, endpoint, *path_parameters)
+    path = "/api/" + "/".join(quote(str(component), safe="") for component in components)
+    query = urlencode(query_parameters or {})
+    relative_target = urlunsplit(("", "", path, query, ""))
+
+    # Keep the user-controlled part relative. This rejects browser URL forms that
+    # could otherwise replace the configured origin.
+    parsed_target = urlsplit(relative_target.replace("\\", ""))
+    if (
+        parsed_target.scheme
+        or parsed_target.netloc
+        or not parsed_target.path.startswith("/api/")
+    ):
+        raise ValueError("Unsafe Schedule Explorer redirect target")
+
+    configured_origin = urlunsplit(
+        ("http", f"{url_host}:{configured_port}", "", "", "")
+    )
+    return configured_origin + relative_target
+
+
+def resolve_provider_asset_directory(
+    providers_root: Union[str, Path],
+    requested_provider_path: str,
+    asset_type: str,
+    registered_provider_paths: Mapping[str, Union[str, Path]],
+) -> Path:
+    """Resolve an asset directory from the registered provider allowlist."""
+    if asset_type not in ALLOWED_PROVIDER_ASSET_TYPES:
+        raise ValueError("Unsupported provider asset type")
+
+    registered_path = registered_provider_paths.get(requested_provider_path)
+    if registered_path is None:
+        raise KeyError(requested_provider_path)
+
+    registered_path = Path(registered_path)
+    if registered_path.is_absolute():
+        raise ValueError("Registered provider paths must be relative")
+
+    root = Path(providers_root).resolve()
+    directory = (root / registered_path / asset_type).resolve()
+    try:
+        directory.relative_to(root)
+    except ValueError as error:
+        raise ValueError("Provider asset directory escapes its root") from error
+    return directory
+
+
+def is_safe_static_path(
+    base_directory: Union[str, Path],
+    filename: str,
+    allowed_extensions: set[str],
+) -> bool:
+    """Return whether a requested static file resolves inside its base directory."""
+    if not filename:
+        return False
+
+    base_path = Path(base_directory).resolve()
+    file_path = (base_path / filename).resolve()
+    try:
+        file_path.relative_to(base_path)
+    except ValueError:
+        return False
+
+    return file_path.suffix.lower() in allowed_extensions and file_path.is_file()

--- a/app/security_utils.py
+++ b/app/security_utils.py
@@ -87,20 +87,6 @@ def resolve_provider_asset_directory(
     return directory
 
 
-def is_safe_static_path(
-    base_directory: Union[str, Path],
-    filename: str,
-    allowed_extensions: set[str],
-) -> bool:
-    """Return whether a requested static file resolves inside its base directory."""
-    if not filename:
-        return False
-
-    base_path = Path(base_directory).resolve()
-    file_path = (base_path / filename).resolve()
-    try:
-        file_path.relative_to(base_path)
-    except ValueError:
-        return False
-
-    return file_path.suffix.lower() in allowed_extensions and file_path.is_file()
+def has_allowed_static_extension(filename: str, allowed_extensions: set[str]) -> bool:
+    """Return whether Flask may try to serve this static-file extension."""
+    return bool(filename) and Path(filename).suffix.lower() in allowed_extensions

--- a/app/test_security_utils.py
+++ b/app/test_security_utils.py
@@ -5,7 +5,7 @@ import pytest
 
 from app.security_utils import (
     build_schedule_explorer_redirect_url,
-    is_safe_static_path,
+    has_allowed_static_extension,
     resolve_provider_asset_directory,
 )
 
@@ -63,16 +63,8 @@ def test_provider_asset_directory_comes_from_registered_allowlist(tmp_path):
         )
 
 
-def test_static_path_rejects_traversal_and_symlink_escape(tmp_path):
-    assets = tmp_path / "assets"
-    assets.mkdir()
-    script = assets / "provider.js"
-    script.write_text("export default {};", encoding="utf-8")
-    outside = tmp_path / "secret.js"
-    outside.write_text("secret", encoding="utf-8")
-    (assets / "linked.js").symlink_to(outside)
-
-    assert is_safe_static_path(assets, "provider.js", {".js"})
-    assert not is_safe_static_path(assets, "../secret.js", {".js"})
-    assert not is_safe_static_path(assets, "linked.js", {".js"})
-    assert not is_safe_static_path(assets, "provider.js", {".css"})
+def test_static_extension_allowlist_is_case_insensitive():
+    assert has_allowed_static_extension("provider.js", {".js"})
+    assert has_allowed_static_extension("provider.JS", {".js"})
+    assert not has_allowed_static_extension("provider.css", {".js"})
+    assert not has_allowed_static_extension("", {".js"})

--- a/app/test_security_utils.py
+++ b/app/test_security_utils.py
@@ -1,0 +1,78 @@
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+
+import pytest
+
+from app.security_utils import (
+    build_schedule_explorer_redirect_url,
+    is_safe_static_path,
+    resolve_provider_asset_directory,
+)
+
+
+def test_schedule_explorer_redirect_keeps_configured_origin_and_encodes_input():
+    url = build_schedule_explorer_redirect_url(
+        "schedule-explorer",
+        8000,
+        "mdb-1234",
+        "stops?next=//evil.example",
+        ("a/b", "value#fragment"),
+        {"next": "https://evil.example/%0aLocation: https://other.example"},
+    )
+
+    parsed = urlsplit(url)
+    assert parsed.scheme == "http"
+    assert parsed.netloc == "schedule-explorer:8000"
+    assert parsed.path == (
+        "/api/mdb-1234/stops%3Fnext%3D%2F%2Fevil.example/"
+        "a%2Fb/value%23fragment"
+    )
+    assert parse_qs(parsed.query) == {
+        "next": ["https://evil.example/%0aLocation: https://other.example"]
+    }
+
+
+@pytest.mark.parametrize(
+    "provider",
+    ("mdb-1@evil.example", "mdb-1/../../etc", "//evil.example", "mdb-anything"),
+)
+def test_schedule_explorer_redirect_rejects_invalid_provider_ids(provider):
+    with pytest.raises(ValueError, match="provider ID"):
+        build_schedule_explorer_redirect_url("localhost", 8000, provider, "stops")
+
+
+def test_provider_asset_directory_comes_from_registered_allowlist(tmp_path):
+    providers_root = tmp_path / "transit_providers"
+    registered = {"be/stib": Path("be/stib")}
+
+    assert resolve_provider_asset_directory(
+        providers_root, "be/stib", "js", registered
+    ) == (providers_root / "be/stib/js").resolve()
+
+    with pytest.raises(KeyError):
+        resolve_provider_asset_directory(
+            providers_root, "../../etc", "js", registered
+        )
+
+    with pytest.raises(ValueError, match="escapes its root"):
+        resolve_provider_asset_directory(
+            providers_root,
+            "bad/provider",
+            "js",
+            {"bad/provider": Path("../../etc")},
+        )
+
+
+def test_static_path_rejects_traversal_and_symlink_escape(tmp_path):
+    assets = tmp_path / "assets"
+    assets.mkdir()
+    script = assets / "provider.js"
+    script.write_text("export default {};", encoding="utf-8")
+    outside = tmp_path / "secret.js"
+    outside.write_text("secret", encoding="utf-8")
+    (assets / "linked.js").symlink_to(outside)
+
+    assert is_safe_static_path(assets, "provider.js", {".js"})
+    assert not is_safe_static_path(assets, "../secret.js", {".js"})
+    assert not is_safe_static_path(assets, "linked.js", {".js"})
+    assert not is_safe_static_path(assets, "provider.js", {".css"})


### PR DESCRIPTION
## What changed

- give the Docker workflow a read-only token by default while retaining package write access only for publishing
- resolve provider asset directories from the registered-provider allowlist and reject traversal or symlink escapes
- validate Mobility Database provider IDs, encode redirect path and query components, and keep the configured Schedule Explorer origin fixed
- keep browser console format strings constant and encode the selected provider before HTML rendering
- exclude local Git, virtualenv, cache, log, configuration, and secret files from Docker build contexts
- run focused security regressions in the Docker workflow

## Validation

- focused tests: 9 passed locally and in the Python 3.12 image
- Docker image build: passed, including GTFS precache compilation
- runtime health: /health returned healthy from the rebuilt image
- hostile redirect and asset requests: fixed-origin 302, invalid provider 404, registered asset 200, traversal-shaped asset request 404
- Trivy HIGH/CRITICAL OS and library scan: 0 findings
- repository-wide pytest: still stops at the existing five collection errors, including the duplicate gtfs-realtime.proto descriptor and stale BKK test import

Addresses CodeQL alerts 25, 26, 27, 45, 46, 47, and 56.